### PR TITLE
feat(ootb): selection-aware startup, idempotent installer reruns, can…

### DIFF
--- a/config/ai-agent.deepgram-agent.yaml
+++ b/config/ai-agent.deepgram-agent.yaml
@@ -30,8 +30,11 @@ providers:
     api_key: "${DEEPGRAM_API_KEY}"
     model: "nova-2-general"
     tts_model: "aura-asteria-en"
+    greeting: "${DEEPGRAM_GREETING:-Hello, how can I help you today?}"
+    instructions: "${DEEPGRAM_INSTRUCTIONS:-You are a concise voice assistant. Respond in under 20 words and answer immediately.}"
     input_encoding: "linear16"
     input_sample_rate_hz: 8000
+    continuous_input: true
     # Output μ-law for telephony playback; engine converts to files or stream per mode
     output_encoding: "mulaw"
     output_sample_rate_hz: 8000


### PR DESCRIPTION
…onical pipelines template; deepgram provider sync; docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Deepgram provider options: greeting, instructions, and continuous_input.
  - Enhanced installer: pipeline/profile selection (Local/Hybrid/Cloud), environment-aware defaults, idempotent config generation, and template-based setup.
  - Mode-based startup: Local/Hybrid starts local AI server then engine; Cloud-only starts engine only.
  - Automatic yq fallback installation for Linux/macOS; resilient YAML updates with sed fallback.
  - Preserves and updates greetings/prompts and API credentials from existing environment.

- Documentation
  - Rewrote Quick Start to a configuration-centric guide with explicit pipelines, provider defaults, and runtime precedence for prompts.
  - Updated cloud-only OpenAI Realtime section and added “Installer behavior” details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->