### PR TITLE
Fix ARI startup race with reconnect supervisor

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import copy
 import logging
 import math
@@ -746,6 +747,7 @@ class Engine:
         self.ari_client.add_event_handler("PlaybackFinished", self._on_playback_finished)
         if not self._ari_listener_task or self._ari_listener_task.done():
             self._ari_listener_task = asyncio.create_task(self.ari_client.start_listening())
+            self._ari_listener_task.add_done_callback(self._on_ari_listener_task_done)
         # Outbound scheduler (runs even if no campaigns are active; lightweight idle)
         try:
             if not self._outbound_scheduler_task:
@@ -762,6 +764,18 @@ class Engine:
         except Exception:
             logger.debug("Failed to start outbound scheduler task", exc_info=True)
         logger.info("Engine started and listening for calls.")
+
+    def _on_ari_listener_task_done(self, task: "asyncio.Task") -> None:
+        """Log background ARI listener task failures (prevents swallowed exceptions)."""
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        except Exception as err:
+            logger.debug("Failed inspecting ARI listener task result", error=str(err))
+            return
+        if exc:
+            logger.error("ARI listener task exited unexpectedly", error=str(exc))
 
     def _parse_port_range(self, value: Optional[Any], fallback_port: int) -> Tuple[int, int]:
         """Parse external_media.port_range into an inclusive (start, end) tuple."""
@@ -1791,6 +1805,11 @@ class Engine:
         for session in sessions:
             await self._cleanup_call(session.call_id)
         await self.ari_client.disconnect()
+        task = getattr(self, "_ari_listener_task", None)
+        if task and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
         # Stop RTP server if running
         if hasattr(self, 'rtp_server') and self.rtp_server:
             await self.rtp_server.stop()

--- a/src/engine_external_media.py
+++ b/src/engine_external_media.py
@@ -4,6 +4,7 @@ Uses ARI External Media channels for bidirectional RTP communication.
 """
 
 import asyncio
+import contextlib
 import os
 import signal
 import uuid
@@ -35,6 +36,7 @@ class ExternalMediaEngine:
     def __init__(self, config: AppConfig):
         self.config = config
         self.ari_client: Optional[ARIClient] = None
+        self._ari_listener_task: Optional[asyncio.Task] = None
         self.rtp_server: Optional[RTPServer] = None
         self.providers: Dict[str, AIProviderInterface] = {}
         self.active_calls: Dict[str, Dict[str, Any]] = {}
@@ -148,7 +150,9 @@ class ExternalMediaEngine:
             self.ari_client.add_event_handler("PlaybackFinished", self._on_playback_finished)
             
             # Start ARI reconnect supervisor (initial connect happens in the background).
-            asyncio.create_task(self.ari_client.start_listening())
+            if not self._ari_listener_task or self._ari_listener_task.done():
+                self._ari_listener_task = asyncio.create_task(self.ari_client.start_listening())
+                self._ari_listener_task.add_done_callback(self._on_ari_listener_task_done)
             logger.info("ARI reconnect supervisor started")
             
             self.running = True
@@ -176,11 +180,29 @@ class ExternalMediaEngine:
             if self.ari_client:
                 await self.ari_client.disconnect()
                 logger.info("ARI client disconnected")
+
+            task = getattr(self, "_ari_listener_task", None)
+            if task and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
             
             logger.info("External Media engine stopped")
             
         except Exception as e:
             logger.error(f"Error stopping External Media engine: {e}")
+
+    def _on_ari_listener_task_done(self, task: "asyncio.Task") -> None:
+        """Log background ARI listener task failures (prevents swallowed exceptions)."""
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        except Exception as err:
+            logger.debug("Failed inspecting ARI listener task result", error=str(err))
+            return
+        if exc:
+            logger.error("ARI listener task exited unexpectedly", error=str(exc))
     
     async def _on_stasis_start(self, event: Dict[str, Any]):
         """Handle StasisStart event - create External Media channel and bridge."""

--- a/tests/test_engine_ari_startup_reconnect.py
+++ b/tests/test_engine_ari_startup_reconnect.py
@@ -7,6 +7,8 @@ from src.engine import Engine
 
 
 class _StubARIClient:
+    """Stub ARI client that simulates startup-time connection failure."""
+
     def __init__(self):
         self.connect_calls = 0
         self.handlers = []
@@ -19,20 +21,24 @@ class _StubARIClient:
         self.handlers.append((event_type, handler))
 
     async def start_listening(self):
+        """Mimic reconnect supervisor behavior without looping forever."""
         # Mimic reconnect supervisor behavior without sleeping/looping forever.
         try:
             await self.connect()
-        except Exception:
+        except ConnectionError:
             return
 
 
 class _StubPipelineOrchestrator:
+    """Stub pipeline orchestrator to avoid dependencies in Engine.start()."""
+
     async def start(self):
         return None
 
 
 @pytest.mark.unit
 async def test_engine_start_does_not_fail_when_ari_unavailable_at_startup():
+    """Engine.start() should schedule ARI reconnect even if ARI is down."""
     engine = Engine.__new__(Engine)
     engine.providers = {}
     engine._call_providers = {}
@@ -59,9 +65,6 @@ async def test_engine_start_does_not_fail_when_ari_unavailable_at_startup():
 
     await engine.start()
 
-    # Let the background task run once.
-    await asyncio.sleep(0)
-
     assert engine._ari_listener_task is not None
+    await asyncio.wait_for(engine._ari_listener_task, timeout=0.1)
     assert engine.ari_client.connect_calls >= 1
-


### PR DESCRIPTION
## Fix ARI startup reconnect after reboot race

### What changed
- Prevent the AI engine from failing startup when ARI is temporarily unavailable (common right after host/FreePBX/Asterisk reboot).
- Start the existing ARI reconnect supervisor immediately at engine start, instead of blocking on an initial `connect()`.

### Why
On reboot, Asterisk/ARI can come up after `ai-engine`. Previously, `Engine.start()` awaited `ari_client.connect()`; if that first connect failed, the engine never scheduled the reconnect supervisor and ARI stayed disconnected indefinitely until a manual restart.

### Implementation
- Start ARI listener/reconnect supervisor in the background and rely on existing reconnect/backoff logic.
- Keep readiness strict: `/ready` remains `503` until ARI is connected.

### Files changed
- [src/engine.py](src/engine.py)
- [src/engine_external_media.py](src/engine_external_media.py)
- [tests/test_engine_ari_startup_reconnect.py](tests/test_engine_ari_startup_reconnect.py)

### How to verify (dev server)
1. Reboot the host or restart Asterisk, and ensure `ai-engine` starts before ARI is ready.
2. Confirm `ai-engine` stays up and `/ready` reports `ari_connected=false` initially.
3. Once Asterisk/ARI is up, confirm `ari_connected=true` and UI shows ARI Connected without restarting `ai-engine`.

### Test coverage
- `pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs ARI connection/reconnect supervision in a guarded background task to avoid startup races.

* **Bug Fixes**
  * Improved startup/shutdown sequencing so external-service unavailability doesn’t cause startup failures and listener failures are surfaced.

* **Tests**
  * Added tests validating startup resilience and ARI reconnection behavior when the external service is temporarily unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->