### PR TITLE
Fix Admin UI media dir permissions after reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Additional provider integrations
 - Enhanced monitoring features
 
+### Fixed
+
+- Admin UI: auto-detect the media directory group inside the container and add `appuser` to that GID at startup, preventing false “media directory not writable” warnings after host reboots on systems where Asterisk uses a non-default group ID.
+
 ## [5.1.6] - 2026-01-20
 
 ### Added

--- a/admin_ui/entrypoint.sh
+++ b/admin_ui/entrypoint.sh
@@ -5,18 +5,46 @@ if [ "$(id -u)" != "0" ]; then
   exec "$@"
 fi
 
-if [ -S /var/run/docker.sock ]; then
-  sock_gid="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock 2>/dev/null || echo "")"
-  if [ -n "${sock_gid:-}" ] && echo "$sock_gid" | grep -Eq '^[0-9]+$'; then
-    if ! id -G appuser 2>/dev/null | tr ' ' '\n' | grep -qx "$sock_gid"; then
-      existing_group="$(awk -F: -v gid="$sock_gid" '$3==gid{print $1; exit}' /etc/group 2>/dev/null || true)"
-      group_name="${existing_group:-dockersock}"
-      if [ -z "${existing_group:-}" ]; then
-        groupadd -g "$sock_gid" "$group_name" 2>/dev/null || true
-      fi
-      usermod -aG "$group_name" appuser 2>/dev/null || true
-    fi
+ensure_user_in_gid() {
+  user="$1"
+  gid="$2"
+  name_hint="${3:-}"
+
+  if [ -z "${gid:-}" ] || ! echo "$gid" | grep -Eq '^[0-9]+$'; then
+    return 0
   fi
+
+  # Skip if already a member of this GID.
+  if id -G "$user" 2>/dev/null | tr ' ' '\n' | grep -qx "$gid"; then
+    return 0
+  fi
+
+  existing_group="$(awk -F: -v gid="$gid" '$3==gid{print $1; exit}' /etc/group 2>/dev/null || true)"
+  group_name="${existing_group:-${name_hint:-gid$gid}}"
+  if [ -z "${existing_group:-}" ]; then
+    groupadd -g "$gid" "$group_name" 2>/dev/null || true
+  fi
+  usermod -aG "$group_name" "$user" 2>/dev/null || true
+}
+
+detect_gid_for_path() {
+  path="$1"
+  stat -c '%g' "$path" 2>/dev/null || stat -f '%g' "$path" 2>/dev/null || echo ""
+}
+
+if [ -S /var/run/docker.sock ]; then
+  sock_gid="$(detect_gid_for_path /var/run/docker.sock)"
+  ensure_user_in_gid appuser "$sock_gid" dockersock
+fi
+
+# Ensure the Admin UI runtime user can validate/write to the media directory (used by health checks).
+# Some distros use a non-default Asterisk group GID (e.g., 996), and the directory can be owned by that group.
+if [ -d /mnt/asterisk_media/ai-generated ]; then
+  media_gid="$(detect_gid_for_path /mnt/asterisk_media/ai-generated)"
+  ensure_user_in_gid appuser "$media_gid" asteriskmedia
+elif [ -d /mnt/asterisk_media ]; then
+  media_gid="$(detect_gid_for_path /mnt/asterisk_media)"
+  ensure_user_in_gid appuser "$media_gid" asteriskmedia
 fi
 
 exec gosu appuser "$@"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -47,6 +47,10 @@ sudo ./preflight.sh --apply-fixes
 Preflight ensures required host directories exist with correct permissions, including:
 - `./data` (Call History SQLite and runtime state)
 - `./models/{stt,tts,llm,kroko}` (mounted into `ai_engine` and `local_ai_server` as `/app/models`)
+- `./asterisk_media/ai-generated` (mounted as `/mnt/asterisk_media/ai-generated` for generated audio)
+
+> Note: Admin UI health checks validate the media directory from within the `admin_ui` container.
+> On some systems Asterisk uses a non-default group ID; newer releases auto-detect this at `admin_ui` startup so the UI doesn't incorrectly warn after reboot.
 
 If preflight reports warnings or failures, resolve them first, then re-run preflight until it returns clean:
 - Troubleshooting: `docs/TROUBLESHOOTING_GUIDE.md`


### PR DESCRIPTION
## Fix Admin UI “media directory not writable” after reboot (auto-detect media GID)

### Problem
Some community installs (notably Debian/FreePBX variants) run Asterisk with a non-default group ID (e.g. `asterisk` GID `996`). After a full VM reboot, the media directory mount can be present and writable for `ai_engine`, but the Admin UI container’s runtime user (`appuser`, UID `1000`) may not be in the media directory’s group. This causes the Admin UI directory health check to incorrectly report **“Media directory not writable”**, leading operators to rerun `preflight.sh` after every reboot.

### Root Cause
- `/mnt/asterisk_media/ai-generated` can be owned by a non-default group (e.g. `999:996`) and `775`.
- `admin_ui` runs as `appuser` (UID 1000) and typically only has groups like `1000,999`, so it cannot write to the media directory even though the mount is correctly persisted.

### Fix
- Extend `admin_ui/entrypoint.sh` to **auto-detect the GID** of `/mnt/asterisk_media/ai-generated` (fallback `/mnt/asterisk_media`) and **add `appuser` to that group at container startup**.
- This mirrors the existing docker socket GID auto-detection logic already in the entrypoint, making the fix self-healing across reboots and across differing Asterisk GIDs.

### Files Changed
- `admin_ui/entrypoint.sh`
- `docs/INSTALLATION.md`
- `CHANGELOG.md`

### How to Verify
1. On a host where `asterisk` uses a non-default GID, reboot the VM/host.
2. Start services: `docker compose up -d admin_ui ai_engine`
3. Confirm Admin UI no longer reports a media directory permission warning.
4. Optional: verify inside the container:
   - `docker compose exec -T --user 1000:1000 admin_ui sh -lc 'touch /mnt/asterisk_media/ai-generated/.w && rm -f /mnt/asterisk_media/ai-generated/.w && echo OK'`

### Notes
- No changes to mount persistence logic; this PR only addresses the Admin UI container’s ability to validate/write to the mounted media directory reliably across reboots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin UI now auto-detects media directory group permissions at startup, preventing false "media directory not writable" warnings after host reboots on systems with non-default Asterisk group IDs.

* **Documentation**
  * Updated installation documentation with media directory mounting requirements and notes about automatic group ID detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->