### PR TITLE
Hotfix v5.2.3: agent update should not start local_ai_server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Additional provider integrations
 - Enhanced monitoring features
 
+## [5.2.3] - 2026-01-26
+
+### Fixed
+
+- Agent CLI: `agent update` no longer runs an unscoped `docker compose up` when Compose files change; it targets only running/impacted services to avoid unintentionally creating optional services (e.g., `local_ai_server`) and failing on systems that never built those images.
+
 ## [5.2.2] - 2026-01-26
 
 ### Fixed

--- a/cli/cmd/agent/main.go
+++ b/cli/cmd/agent/main.go
@@ -8,12 +8,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-	var (
-		version   = "5.2.2"     // Overridden at build time via -ldflags
-		buildTime = "unknown"   // Overridden at build time via -ldflags
-		verbose   bool
-		noColor   bool
-	)
+var (
+	version   = "5.2.3"   // Overridden at build time via -ldflags
+	buildTime = "unknown" // Overridden at build time via -ldflags
+	verbose   bool
+	noColor   bool
+)
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,12 +1,12 @@
-# Asterisk AI Voice Agent - Installation Guide (v5.2.2)
+# Asterisk AI Voice Agent - Installation Guide (v5.2.3)
 
-This guide provides detailed instructions for setting up the Asterisk AI Voice Agent v5.2.2 on your server.
+This guide provides detailed instructions for setting up the Asterisk AI Voice Agent v5.2.3 on your server.
 
 ## Three Setup Paths
 
 Choose the path that best fits your experience level:
 
-## Upgrade from v4.6.0 → v5.2.2 (Existing Checkout)
+## Upgrade from v4.6.0 → v5.2.3 (Existing Checkout)
 
 This section is for operators upgrading an existing repo checkout (not a fresh install).
 
@@ -18,11 +18,11 @@ This section is for operators upgrading an existing repo checkout (not a fresh i
 
 ### 1) Pull the new release
 
-Once `v5.2.2` is published:
+Once `v5.2.3` is published:
 
 ```bash
 git fetch --tags
-git checkout v5.2.2
+git checkout v5.2.3
 ```
 
 If you track branches instead of tags:
@@ -67,6 +67,31 @@ cd /root/Asterisk-AI-Voice-Agent
 INSTALL_DIR=/usr/local/bin bash scripts/install-cli.sh
 agent version
 agent update
+```
+
+#### If the update fails with “No such image: ...local-ai-server:latest”
+
+Some installations never started or built the optional `local_ai_server` container (for example, if you only use remote providers).
+Older `agent update` versions could still try to recreate `local_ai_server` when Compose files change.
+
+To recover without enabling `local_ai_server`, bring up only the services you actually run:
+
+```bash
+cd /root/Asterisk-AI-Voice-Agent
+
+# If the update planned to rebuild admin_ui, run this once (safe even if not needed):
+docker compose build admin_ui
+
+docker compose up -d --remove-orphans --no-build ai_engine admin_ui
+agent check
+```
+
+If you *do* want `local_ai_server`, build it and then re-run compose:
+
+```bash
+cd /root/Asterisk-AI-Voice-Agent
+docker compose build local_ai_server
+docker compose up -d --remove-orphans --no-build
 ```
 
 ### 2) Re-run preflight (recommended)
@@ -219,7 +244,7 @@ agent setup
 
 **Best for:** Headless servers, scripted deployments, CLI preference
 
-> Note: `agent quickstart` and `agent init` are still available for backward compatibility, but `agent setup` is the recommended CLI wizard for v5.2.2.
+> Note: `agent quickstart` and `agent init` are still available for backward compatibility, but `agent setup` is the recommended CLI wizard for v5.2.3.
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes `agent update` failures on systems that never built/ran `local_ai_server`.

## Problem
When Docker Compose files changed, `agent update` ran an unscoped:
- `docker compose up -d --remove-orphans --no-build`

On servers where only `ai_engine` + `admin_ui` were previously started, this could still attempt to (re)create the optional `local_ai_server` service and fail with:
- `No such image: asterisk-ai-voice-agent-local-ai-server:latest`

## Fix
- Scope the compose-changed `docker compose up` to **running/impacted services only**.
- Avoid restarting services that aren't already running unless they are explicitly being rebuilt.

## Docs
- `docs/INSTALLATION.md` now includes a recovery snippet for the `No such image ...local-ai-server:latest` case.

## Testing
- Local: `python3 -m py_compile admin_ui/backend/api/system.py`
- Local: `bash -n updater/run.sh`
- Manual reproduction validated on a host where `local_ai_server` was not built.

## Release
After merge, tag `v5.2.3` to publish CLI binaries + GHCR images.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent CLI update now targets only running/impacted services by default, preventing unscoped Docker Compose operations that could create optional services or fail on systems with missing images.

* **Documentation**
  * Updated installation guide with backup recommendations, enhanced troubleshooting steps for update failures, and version references for v5.2.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->