### PR TITLE
Docs: align README/Troubleshooting to v5.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Asterisk AI Voice Agent
 
-![Version](https://img.shields.io/badge/version-5.2.1-blue.svg)
+![Version](https://img.shields.io/badge/version-5.2.3-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Python](https://img.shields.io/badge/python-3.11+-blue.svg)
 ![Docker](https://img.shields.io/badge/docker-compose-blue.svg)
@@ -21,7 +21,7 @@ The most powerful, flexible open-source AI voice agent for Asterisk/FreePBX. Fea
 ## 📖 Table of Contents
 
 - [🚀 Quick Start](#-quick-start)
-- [🎉 What's New](#-whats-new-in-v521)
+- [🎉 What's New](#-whats-new-in-v523)
 - [🌟 Why Asterisk AI Voice Agent?](#-why-asterisk-ai-voice-agent)
 - [✨ Features](#-features)
 - [🎥 Demo](#-demo)
@@ -110,7 +110,7 @@ For users who prefer the command line or need headless setup.
 agent setup
 ```
 
-> Note: Legacy commands `agent init`, `agent doctor`, and `agent troubleshoot` remain available as hidden aliases in CLI v5.2.1.
+> Note: Legacy commands `agent init`, `agent doctor`, and `agent troubleshoot` remain available as hidden aliases in CLI v5.2.3.
 
 ### Option B: Manual Setup
 ```bash
@@ -126,7 +126,7 @@ docker compose up -d
 Add this to your FreePBX (`extensions_custom.conf`):
 ```asterisk
 [from-ai-agent]
-exten => s,1,NoOp(Asterisk AI Voice Agent v5.2.1)
+exten => s,1,NoOp(Asterisk AI Voice Agent)
  ; Optional per-call overrides:
  ; - AI_PROVIDER selects a provider/pipeline (otherwise uses default_provider from ai-agent.yaml)
  ; - AI_CONTEXT selects a context/persona (otherwise uses default context)
@@ -153,7 +153,7 @@ docker compose logs -f ai_engine
 
 ---
 
-## 🎉 What's New in v5.2.1
+## 🎉 What's New in v5.2.3
 
 <details open>
 <summary><b>Latest Updates</b></summary>
@@ -162,6 +162,10 @@ docker compose logs -f ai_engine
 - Admin UI: **System → Updates** page (GitHub-style): check updates → choose branch → preview impact → proceed
 - Preview shows **files changed** and **containers to rebuild/restart** (with opt-in “Update UI too”)
 - Detached updater job survives `admin_ui` rebuild/restarts and keeps a **Recent Runs** summary with rollback options
+
+### 🛠️ Update Hardening (v5.2.2 → v5.2.3)
+- Agent CLI: `agent update` now uses an explicit fetch refspec so `origin/<ref>` is reliably updated (prevents false “Already up to date”)
+- Agent CLI: compose-change updates target only running/impacted services (avoids trying to start optional `local_ai_server` on servers that never built it)
 
 For full release notes, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -15,8 +15,8 @@ This guide is for contributors who want to run the repo locally, make changes, a
    - Configs: `config/ai-agent.golden-*.yaml`
    - Quick references: `docs/baselines/golden/`
 4. Validate and troubleshoot calls:
-   - `agent check`, `agent rca` (v5.2.1)
-   - Legacy aliases (v5.2.1): `agent doctor`, `agent troubleshoot`
+   - `agent check`, `agent rca` (v5.2.3)
+   - Legacy aliases (v5.2.3): `agent doctor`, `agent troubleshoot`
    - RCA bundle capture: `scripts/rca_collect.sh`
 
 ## Where To Make Changes

--- a/docs/TROUBLESHOOTING_GUIDE.md
+++ b/docs/TROUBLESHOOTING_GUIDE.md
@@ -84,12 +84,12 @@ Note: The CLI binary and the Python engine may have different version strings de
 
 ### Available Tools
 
-- **`agent setup`** - Interactive setup wizard (v5.2.1)
-- **`agent check`** - Standard diagnostics report (v5.2.1)
-- **`agent rca`** - Post-call root cause analysis (v5.2.1)
+- **`agent setup`** - Interactive setup wizard (v5.2.3)
+- **`agent check`** - Standard diagnostics report (v5.2.3)
+- **`agent rca`** - Post-call root cause analysis (v5.2.3)
 - **`agent update`** - Pull latest code + rebuild/restart as needed (v5.1+)
 
-Legacy aliases (v5.2.1; hidden from `--help`):
+Legacy aliases (v5.2.3; hidden from `--help`):
 - `agent init` → `agent setup`
 - `agent doctor` → `agent check`
 - `agent troubleshoot` → `agent rca`
@@ -643,7 +643,7 @@ agent demo -v
 # Run setup wizard
 agent setup
 
-# Flags below are planned; they may exist but are not implemented in v5.2.1:
+# Flags below are planned; they may exist but are not implemented in v5.2.3:
 # agent setup --non-interactive
 # agent setup --template <name>
 ```
@@ -1470,7 +1470,7 @@ streaming:
 
 ```
 [from-ai-agent]
-exten => s,1,NoOp(AI Voice Agent v5.2.1)
+exten => s,1,NoOp(AI Voice Agent)
  same => n,Answer()
  same => n,Set(AI_CONTEXT=demo_openai)  ; Optional: select context
  same => n,Stasis(asterisk-ai-voice-agent)
@@ -1513,5 +1513,5 @@ See [docs/Transport-Mode-Compatibility.md](Transport-Mode-Compatibility.md) for 
 
 ---
 
-**Last Updated:** January 12, 2026  
-**Version:** 5.2.1
+**Last Updated:** January 26, 2026  
+**Version:** 5.2.3


### PR DESCRIPTION
Updates operator-facing docs to reflect the current release `v5.2.3`.

- README version badge + “What’s New” section updated for v5.2.3
- Remove hard-coded version from dialplan `NoOp(...)` example (avoids doc drift)
- Troubleshooting guide + developer onboarding version references updated
