### PR TITLE
Docs: align version references to v5.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Asterisk AI Voice Agent
 
-![Version](https://img.shields.io/badge/version-5.2.3-blue.svg)
+![Version](https://img.shields.io/badge/version-5.2.4-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Python](https://img.shields.io/badge/python-3.11+-blue.svg)
 ![Docker](https://img.shields.io/badge/docker-compose-blue.svg)
@@ -21,7 +21,7 @@ The most powerful, flexible open-source AI voice agent for Asterisk/FreePBX. Fea
 ## 📖 Table of Contents
 
 - [🚀 Quick Start](#-quick-start)
-- [🎉 What's New](#-whats-new-in-v523)
+- [🎉 What's New](#-whats-new-in-v524)
 - [🌟 Why Asterisk AI Voice Agent?](#-why-asterisk-ai-voice-agent)
 - [✨ Features](#-features)
 - [🎥 Demo](#-demo)

--- a/cli/cmd/agent/main.go
+++ b/cli/cmd/agent/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	version   = "5.2.3"   // Overridden at build time via -ldflags
+	version   = "5.2.4"   // Overridden at build time via -ldflags
 	buildTime = "unknown" // Overridden at build time via -ldflags
 	verbose   bool
 	noColor   bool

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -15,8 +15,8 @@ This guide is for contributors who want to run the repo locally, make changes, a
    - Configs: `config/ai-agent.golden-*.yaml`
    - Quick references: `docs/baselines/golden/`
 4. Validate and troubleshoot calls:
-   - `agent check`, `agent rca` (v5.2.3)
-   - Legacy aliases (v5.2.3): `agent doctor`, `agent troubleshoot`
+   - `agent check`, `agent rca` (v5.2.4)
+   - Legacy aliases (v5.2.4): `agent doctor`, `agent troubleshoot`
    - RCA bundle capture: `scripts/rca_collect.sh`
 
 ## Where To Make Changes

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,12 +1,12 @@
-# Asterisk AI Voice Agent - Installation Guide (v5.2.3)
+# Asterisk AI Voice Agent - Installation Guide (v5.2.4)
 
-This guide provides detailed instructions for setting up the Asterisk AI Voice Agent v5.2.3 on your server.
+This guide provides detailed instructions for setting up the Asterisk AI Voice Agent v5.2.4 on your server.
 
 ## Three Setup Paths
 
 Choose the path that best fits your experience level:
 
-## Upgrade from v4.6.0 → v5.2.3 (Existing Checkout)
+## Upgrade from v4.6.0 → v5.2.4 (Existing Checkout)
 
 This section is for operators upgrading an existing repo checkout (not a fresh install).
 
@@ -18,11 +18,11 @@ This section is for operators upgrading an existing repo checkout (not a fresh i
 
 ### 1) Pull the new release
 
-Once `v5.2.3` is published:
+Once `v5.2.4` is published:
 
 ```bash
 git fetch --tags
-git checkout v5.2.3
+git checkout v5.2.4
 ```
 
 If you track branches instead of tags:
@@ -244,7 +244,7 @@ agent setup
 
 **Best for:** Headless servers, scripted deployments, CLI preference
 
-> Note: `agent quickstart` and `agent init` are still available for backward compatibility, but `agent setup` is the recommended CLI wizard for v5.2.3.
+> Note: `agent quickstart` and `agent init` are still available for backward compatibility, but `agent setup` is the recommended CLI wizard for v5.2.4.
 
 ---
 

--- a/docs/TROUBLESHOOTING_GUIDE.md
+++ b/docs/TROUBLESHOOTING_GUIDE.md
@@ -84,12 +84,12 @@ Note: The CLI binary and the Python engine may have different version strings de
 
 ### Available Tools
 
-- **`agent setup`** - Interactive setup wizard (v5.2.3)
-- **`agent check`** - Standard diagnostics report (v5.2.3)
-- **`agent rca`** - Post-call root cause analysis (v5.2.3)
+- **`agent setup`** - Interactive setup wizard (v5.2.4)
+- **`agent check`** - Standard diagnostics report (v5.2.4)
+- **`agent rca`** - Post-call root cause analysis (v5.2.4)
 - **`agent update`** - Pull latest code + rebuild/restart as needed (v5.1+)
 
-Legacy aliases (v5.2.3; hidden from `--help`):
+Legacy aliases (v5.2.4; hidden from `--help`):
 - `agent init` → `agent setup`
 - `agent doctor` → `agent check`
 - `agent troubleshoot` → `agent rca`
@@ -643,7 +643,7 @@ agent demo -v
 # Run setup wizard
 agent setup
 
-# Flags below are planned; they may exist but are not implemented in v5.2.3:
+# Flags below are planned; they may exist but are not implemented in v5.2.4:
 # agent setup --non-interactive
 # agent setup --template <name>
 ```
@@ -1514,4 +1514,4 @@ See [docs/Transport-Mode-Compatibility.md](Transport-Mode-Compatibility.md) for 
 ---
 
 **Last Updated:** January 26, 2026  
-**Version:** 5.2.3
+**Version:** 5.2.4


### PR DESCRIPTION
Updates README + operator docs to reference v5.2.4 (badge, Installation Guide version, troubleshooting tool versions) and bumps the CLI default version string to 5.2.4 (still overridden by ldflags in release builds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation resources including README, installation guide, troubleshooting guide, and developer onboarding materials to reflect version 5.2.4.
  * Added recommended backup procedure for environment files and configuration in the installation guide.

* **Chores**
  * Released version 5.2.4 with corresponding version bumps across all materials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->