### PR TITLE
Hotfix: build updater image with host network (AAVA-158)

### DIFF
--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -2992,7 +2992,7 @@ def _ensure_updater_image_for_sha(host_project_root: str, tag: str) -> None:
                     decode=True,
                 )
                 _ingest_build_logs(logs)
-            except TypeError as e:
+            except TypeError:
                 logger.warning(
                     "docker-py images.build TypeError with network_mode/decode; retrying without decode (network_mode=host).",
                     exc_info=True,
@@ -3025,19 +3025,7 @@ def _ensure_updater_image_for_sha(host_project_root: str, tag: str) -> None:
         except HTTPException:
             raise
         except docker.errors.BuildError as e:
-            try:
-                for chunk in (getattr(e, "build_log", None) or []):
-                    if isinstance(chunk, dict):
-                        if "stream" in chunk:
-                            _capture_line(str(chunk.get("stream") or ""))
-                        if "error" in chunk:
-                            _capture_line(str(chunk.get("error") or ""))
-                    elif isinstance(chunk, (bytes, bytearray)):
-                        _capture_line(chunk.decode("utf-8", errors="replace"))
-                    else:
-                        _capture_line(str(chunk))
-            except Exception:
-                pass
+            _ingest_build_logs(getattr(e, "build_log", None) or [])
 
             tail = "\n".join(last_lines[-25:]).strip()
             if tail:


### PR DESCRIPTION
## Summary
Fixes Updates UI failures where building the updater runner image fails in environments where Docker bridge DNS/egress is restricted (e.g. `proxy.golang.org` resolution timeouts during `go mod download`).

## Related Issues
- AAVA-158

## Implementation Notes
- `admin_ui/backend/api/system.py` now builds the updater image with `network_mode=host` to use host DNS/routing.
- Captures a short tail of Docker build output to aid support triage.
- Adds explicit warning logs when falling back due to older docker-py clients that don’t support `network_mode`/`decode`.

## Testing
- Reproduced failure: updater build fails with DNS timeout to `proxy.golang.org` when using Docker bridge networking.
- Verified workaround: `docker buildx build --network=host -f updater/Dockerfile .` succeeds.
- CI: GitHub Actions checks pass.

## Documentation
- No docs changes in this PR (UI error includes a recovery command).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and retry behavior for system image builds to increase reliability.
  * Enhanced capture and preservation of build logs, surfacing concise log tails on failures for clearer context.
  * Added actionable DNS/network diagnostic hints in error responses to aid troubleshooting while preserving existing error propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->