### PR TITLE
GA 5.3.1: fix in-call HTTP tools wiring + secure test endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Deepgram Language Configuration**: Voice Agent language is now configurable via Admin UI and YAML (`agent_language` field). Supports 30+ languages including English variants, Spanish, French, German, Japanese, Chinese, and more.
+- **Phase Tools (Milestone 24)**: Pre-call HTTP lookups (enrichment), in-call HTTP tools (AI-invoked during conversation), and post-call webhooks (fire-and-forget automation).
+- **Extension Availability Tool (AAVA-53)**: New `check_extension_status` tool to query Asterisk device state (e.g., `PJSIP/2765`) so the AI can decide whether to transfer or continue.
+- **Hangup Policy Controls**: `hangup_call` now supports a configurable policy (markers and guardrails) via `tools.hangup_call.policy`.
+- **Admin UI YAML Error Recovery**: YAML parse errors now show a banner with line/column and the Raw YAML page can still load content for quick fixes.
+- **Agent CLI RCA Enhancements**: `agent rca [call_id]` support, optional `--llm` forcing, and tool call extraction to improve post-call debugging.
 
 ### Fixed
 
@@ -24,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Admin UI Setup Wizard (AAVA-164)**: ElevenLabs Agent ID field now auto-populates from `.env` file when re-running the wizard.
 - **Admin UI Log Export (AAVA-162)**: Exported debug logs now redact email addresses (`[EMAIL_REDACTED]`) to protect user privacy.
 - **Admin UI Environment Changes (AAVA-161)**: "Apply Changes" after modifying `.env` variables now uses `docker compose --force-recreate` instead of container restart, ensuring environment variable changes are actually applied (e.g., `LOG_TO_FILE`, `LOG_FILE_PATH`).
+- **In-Call HTTP Tools Config Wiring**: Align tool schema across engine/Admin UI/docs and support context allowlisting of in-call HTTP tools.
+- **Google Live Transcription Stability**: Reduce duplicate transcript fragments and improve output PCM rate detection from provider mimeType.
+
+### Security
+
+- Admin UI HTTP tool **Test** now blocks localhost/private targets by default (SSRF mitigation); can be overridden for trusted networks via environment variables.
 
 ## [5.2.5] - 2026-01-28
 

--- a/admin_ui/Tools_Setup_Guide.md
+++ b/admin_ui/Tools_Setup_Guide.md
@@ -26,6 +26,15 @@ This guide explains how to set up **Pre-Call HTTP Lookups**, **In-Call HTTP Tool
 2. API keys for your integration platform (GoHighLevel, n8n, Make)
 3. Webhook URLs from your automation platform
 
+### Security Note (HTTP Tool Testing)
+
+The Admin UI **Test** button makes real outbound HTTP requests.
+
+- Run the Admin UI only on a **trusted network** (LAN/VPN) and avoid exposing it publicly.
+- By default, the test endpoint blocks requests to localhost/private targets to reduce SSRF risk.
+  - To allow private/localhost testing (trusted network only), set `AAVA_HTTP_TOOL_TEST_ALLOW_PRIVATE=1`.
+  - To allow specific hostnames, set `AAVA_HTTP_TOOL_TEST_ALLOW_HOSTS=host1,host2`.
+
 ---
 
 ## Part 1: Pre-Call HTTP Lookups

--- a/admin_ui/backend/tests/test_http_tool_test_security.py
+++ b/admin_ui/backend/tests/test_http_tool_test_security.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+from fastapi import HTTPException
+
+from api.tools import _validate_http_tool_test_target
+
+
+def test_validate_http_tool_test_target_blocks_localhost_by_default(monkeypatch):
+    monkeypatch.delenv("AAVA_HTTP_TOOL_TEST_ALLOW_PRIVATE", raising=False)
+    monkeypatch.delenv("AAVA_HTTP_TOOL_TEST_ALLOW_HOSTS", raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        _validate_http_tool_test_target("http://127.0.0.1:8080/test")
+    assert exc.value.status_code == 403
+
+
+def test_validate_http_tool_test_target_allows_localhost_with_override(monkeypatch):
+    monkeypatch.setenv("AAVA_HTTP_TOOL_TEST_ALLOW_PRIVATE", "1")
+    monkeypatch.delenv("AAVA_HTTP_TOOL_TEST_ALLOW_HOSTS", raising=False)
+
+    _validate_http_tool_test_target("http://127.0.0.1:8080/test")
+
+
+def test_validate_http_tool_test_target_rejects_non_http_scheme(monkeypatch):
+    monkeypatch.setenv("AAVA_HTTP_TOOL_TEST_ALLOW_PRIVATE", "1")
+    with pytest.raises(HTTPException) as exc:
+        _validate_http_tool_test_target("file:///etc/passwd")
+    assert exc.value.status_code == 400
+
+
+def test_validate_http_tool_test_target_rejects_embedded_credentials(monkeypatch):
+    monkeypatch.setenv("AAVA_HTTP_TOOL_TEST_ALLOW_PRIVATE", "1")
+    with pytest.raises(HTTPException) as exc:
+        _validate_http_tool_test_target("http://user:pass@example.com/test")
+    assert exc.value.status_code == 400
+

--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -50,7 +50,7 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
         updateConfig(phase, newTools);
     };
 
-    const handleGlobalToolDisable = (phase: 'disable_global_pre_call_tools' | 'disable_global_post_call_tools' | 'disable_global_in_call_http_tools', toolName: string) => {
+    const handleGlobalToolDisable = (phase: 'disable_global_pre_call_tools' | 'disable_global_post_call_tools' | 'disable_global_in_call_tools', toolName: string) => {
         const currentDisabled = config[phase] || [];
         const newDisabled = currentDisabled.includes(toolName)
             ? currentDisabled.filter((t: string) => t !== toolName)
@@ -61,7 +61,7 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
     const isGlobalToolDisabled = (phase: 'pre_call' | 'post_call' | 'in_call', toolName: string) => {
         const key = phase === 'pre_call' ? 'disable_global_pre_call_tools' 
             : phase === 'post_call' ? 'disable_global_post_call_tools'
-            : 'disable_global_in_call_http_tools';
+            : 'disable_global_in_call_tools';
         return (config[key] || []).includes(toolName);
     };
 
@@ -320,7 +320,7 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
                                                 type="button"
                                                 onClick={(e) => {
                                                     e.preventDefault();
-                                                    handleGlobalToolDisable('disable_global_in_call_http_tools', tool.name);
+                                                    handleGlobalToolDisable('disable_global_in_call_tools', tool.name);
                                                 }}
                                                 className={`text-xs px-2 py-0.5 rounded ${
                                                     isGlobalToolDisabled('in_call', tool.name)

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -275,6 +275,7 @@ Requirements:
 ### Deepgram Voice Agent
 
 - providers.deepgram.api_key, model, tts_model.
+- `providers.deepgram.agent_language`: Language for Deepgram Voice Agent mode (default: `en`).
 - providers.deepgram.greeting: Agent greeting. Leave empty to inherit `llm.initial_greeting`.
 - providers.deepgram.instructions: Persona override for the “think” stage; leave empty to inherit `llm.prompt`.
 - providers.deepgram.input_encoding/input_sample_rate_hz: Keep `input_encoding=ulaw` at 8 kHz when AudioSocket runs μ-law transport.
@@ -377,8 +378,24 @@ Each context supports the following fields:
 - `greeting`: Initial greeting spoken when call connects.
 - `profile`: Audio profile name to use for this context.
 - `provider`: Provider override for this context.
-- `tools`: List of tool names to enable for this context.
+- `tools`: List of **in-call** tool names to enable for this context.
+- `pre_call_tools`: List of pre-call tool names to run after answer, before the AI speaks (HTTP lookups/enrichment).
+- `in_call_http_tools`: List of in-call HTTP tool names to allowlist for this context (defined under `in_call_tools:`).
+- `post_call_tools`: List of post-call tool names to run after the call ends (webhooks/automation).
+- `disable_global_pre_call_tools`: Disable specific global pre-call tools for this context.
+- `disable_global_in_call_tools`: Disable specific global in-call tools for this context.
+- `disable_global_post_call_tools`: Disable specific global post-call tools for this context.
 - `background_music`: Music On Hold class name for ambient music during calls (see below).
+
+### HTTP Tools (Phase Tools)
+
+HTTP tools are configured in YAML and/or via the Admin UI:
+
+- **Pre-call HTTP lookups**: live under `tools:<name>` with `kind: generic_http_lookup` and `phase: pre_call`.
+- **Post-call webhooks**: live under `tools:<name>` with `kind: generic_webhook` and `phase: post_call`.
+- **In-call HTTP tools**: live under `in_call_tools:<name>` with `kind: in_call_http_lookup` (AI-invoked during conversation).
+
+See `docs/TOOL_CALLING_GUIDE.md` for full examples and variable substitution details.
 
 ### Background Music
 
@@ -424,6 +441,16 @@ providers:
 Other provider configs should use environment variables directly via Python's `os.getenv()` in their implementation, or reference env vars in `.env` which are loaded at startup.
 
 **Note**: Future versions may extend env var resolution to all provider configurations.
+
+## Admin UI HTTP Tool Testing (Security)
+
+The Admin UI includes an HTTP tool **Test** feature that makes real outbound HTTP requests.
+
+By default, the Admin UI blocks test requests to localhost/private targets to reduce SSRF risk if the UI is exposed beyond a trusted network.
+
+- `AAVA_HTTP_TOOL_TEST_ALLOW_PRIVATE=1`: allow private/localhost targets (trusted network only).
+- `AAVA_HTTP_TOOL_TEST_ALLOW_HOSTS=host1,host2`: allow specific hostnames.
+- `AAVA_HTTP_TOOL_TEST_FOLLOW_REDIRECTS=1`: allow redirects (default is disabled).
 
 
 ## Tips

--- a/docs/TOOL_CALLING_GUIDE.md
+++ b/docs/TOOL_CALLING_GUIDE.md
@@ -435,7 +435,7 @@ Unlike pre-call tools (automatic, before AI speaks) and post-call webhooks (afte
 ### In-Call HTTP Tool Configuration
 
 ```yaml
-in_call_http_tools:
+in_call_tools:
   check_availability:
     kind: in_call_http_lookup
     enabled: true
@@ -468,6 +468,22 @@ in_call_http_tools:
     error_message: "I'm sorry, I couldn't check availability right now."
 ```
 
+### Enable In-Call HTTP Tools per Context
+
+In-call HTTP tools are allowlisted per context (same as other in-call tools). In the Admin UI, you enable these under **Contexts → In-Call Tools**.
+
+**Example**:
+```yaml
+contexts:
+  support:
+    tools:
+      - hangup_call
+      - attended_transfer
+    in_call_http_tools:
+      - check_availability
+      - order_status
+```
+
 ### Variable Substitution (Precedence)
 
 In-call HTTP tools have access to three types of variables:
@@ -492,7 +508,7 @@ This means you can use data fetched by pre-call tools in your in-call tool reque
 **Order Status Lookup**:
 
 ```yaml
-in_call_http_tools:
+in_call_tools:
   order_status:
     kind: in_call_http_lookup
     enabled: true
@@ -517,7 +533,7 @@ in_call_http_tools:
 **Appointment Booking**:
 
 ```yaml
-in_call_http_tools:
+in_call_tools:
   book_appointment:
     kind: in_call_http_lookup
     enabled: true

--- a/docs/contributing/milestones/milestone-24-tools-enhancements.md
+++ b/docs/contributing/milestones/milestone-24-tools-enhancements.md
@@ -1,6 +1,6 @@
 # Milestone 24: Tool System Enhancements (Pre-Call, In-Call, Post-Call)
 
-**Status**: � In Progress  
+**Status**: In Progress  
 **Priority**: High  
 **Estimated Effort**: 3–4 weeks (MVP)  
 **Branch**: `develop`  
@@ -869,7 +869,7 @@ Unlike pre-call tools (which run before AI speaks) and post-call webhooks (which
 **Configuration Example**:
 
 ```yaml
-in_call_http_tools:
+in_call_tools:
   check_availability:
     kind: in_call_http_lookup
     enabled: true

--- a/src/config.py
+++ b/src/config.py
@@ -577,6 +577,9 @@ class AppConfig(BaseModel):
     contexts: Dict[str, Any] = Field(default_factory=dict)
     # Tool calling configuration (v4.1)
     tools: Dict[str, Any] = Field(default_factory=dict)
+    # In-call HTTP tool definitions (Milestone 24)
+    # Admin UI stores AI-invokable HTTP tool configs under `in_call_tools:`.
+    in_call_tools: Dict[str, Any] = Field(default_factory=dict)
     # MCP tool configuration (experimental)
     mcp: Optional[MCPConfig] = None
     # Farewell hangup delay - seconds to wait after farewell audio completes before hangup
@@ -648,7 +651,22 @@ def load_config(path: str = "config/ai-agent.yaml") -> AppConfig:
     # Phase 1: Load YAML file with environment variable expansion
     path = resolve_config_path(path)
     config_data = load_yaml_with_env_expansion(path)
-    
+
+    # Backward compatibility: older docs/configs used `in_call_http_tools` at the top-level.
+    # Canonical key is now `in_call_tools` (dict of tool_name -> config).
+    try:
+        if (
+            isinstance(config_data, dict)
+            and isinstance(config_data.get("in_call_http_tools"), dict)
+            and not isinstance(config_data.get("in_call_tools"), dict)
+        ):
+            logger.warning(
+                "Config uses deprecated top-level `in_call_http_tools`; migrating to `in_call_tools`",
+            )
+            config_data["in_call_tools"] = config_data.pop("in_call_http_tools")
+    except Exception:
+        logger.debug("Failed normalizing in-call tool key alias", exc_info=True)
+
     # Phase 2: Security - Inject credentials from environment variables only
     inject_asterisk_credentials(config_data)
     inject_llm_config(config_data)


### PR DESCRIPTION
## PR: GA 5.3.1 readiness fixes

### Summary
- Fix in-call HTTP tools wiring across engine/config/Admin UI/docs:
  - Add `in_call_tools` to AppConfig (and alias deprecated top-level `in_call_http_tools`)
  - Support `contexts.<ctx>.in_call_http_tools` as a list (UI) or dict (inline defs)
  - Ensure provider tool allowlisting includes in-call HTTP tools
  - Fix Admin UI key: `disable_global_in_call_tools`
- Add SSRF guardrails to Admin UI HTTP tool “Test” endpoint:
  - Block localhost/private targets by default
  - Allow explicit opt-in via env vars
  - Disable redirects by default
  - Add unit tests
- Update docs + changelog for 5.3.1

### Testing
- Dev server (voiprnd):
  - ai-engine: `pytest -q tests/tools/test_phase_tool_integration.py tests/tools/test_in_call_http_lookup.py` (48 passed)
  - admin-ui backend: `pytest -q` (12 passed)
  - `docker compose up -d --build ai_engine admin_ui` succeeded
  - `/ready` and `/health` endpoints OK

### Notes
- Admin UI HTTP tool testing blocks private targets by default; operators can override with:
  - `AAVA_HTTP_TOOL_TEST_ALLOW_PRIVATE=1`
  - `AAVA_HTTP_TOOL_TEST_ALLOW_HOSTS=host1,host2`
  - `AAVA_HTTP_TOOL_TEST_FOLLOW_REDIRECTS=1`
