### PR TITLE
Hotfix: Admin UI tools API import

### DIFF
--- a/admin_ui/backend/api/tools.py
+++ b/admin_ui/backend/api/tools.py
@@ -13,7 +13,7 @@ import time
 import ipaddress
 import socket
 from urllib.parse import urlparse, urljoin
-from ..settings import get_setting
+from settings import get_setting
 
 router = APIRouter()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Fix Admin UI crash-loop on startup caused by an invalid relative import in `admin_ui/backend/api/tools.py`.

## What changed
- Replace `from ..settings import get_setting` with `from settings import get_setting`.

## Why
- In the Admin UI container, `/app` is not treated as a package root for `..settings`, so the relative import raises `ImportError: attempted relative import beyond top-level package`, causing the `admin_ui` container to restart continuously.

## Verification
- `python3 -m compileall -q admin_ui/backend`
- `pytest -q`

## Notes
- No new tag requested; this PR is a hotfix on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->