### PR TITLE
feat: Asterisk Config Discovery — preflight audit + Admin UI status page

### DIFF
--- a/admin_ui/frontend/src/App.tsx
+++ b/admin_ui/frontend/src/App.tsx
@@ -42,6 +42,7 @@ const LogsPage = lazy(() => import('./pages/System/LogsPage'));
 const TerminalPage = lazy(() => import('./pages/System/TerminalPage'));
 const ModelsPage = lazy(() => import('./pages/System/ModelsPage'));
 const UpdatesPage = lazy(() => import('./pages/System/UpdatesPage'));
+const AsteriskPage = lazy(() => import('./pages/System/AsteriskPage'));
 
 // Loading fallback for lazy-loaded pages
 const PageLoader = () => (
@@ -157,6 +158,7 @@ function App() {
                                             {/* System Management */}
                                             <Route path="/env" element={<EnvPage />} />
                                             <Route path="/docker" element={<DockerPage />} />
+                                            <Route path="/asterisk" element={<AsteriskPage />} />
                                             <Route path="/logs" element={<LogsPage />} />
                                             <Route path="/terminal" element={<TerminalPage />} />
                                             <Route path="/models" element={<ModelsPage />} />

--- a/admin_ui/frontend/src/components/layout/Sidebar.tsx
+++ b/admin_ui/frontend/src/components/layout/Sidebar.tsx
@@ -100,6 +100,7 @@ const Sidebar = () => {
                 <SidebarGroup title="System">
                     <SidebarItem to="/env" icon={Globe} label="Environment" />
                     <SidebarItem to="/docker" icon={Container} label="Docker Services" />
+                    <SidebarItem to="/asterisk" icon={Phone} label="Asterisk" />
                     <SidebarItem to="/models" icon={HardDrive} label="Models" />
                     <SidebarItem to="/updates" icon={ArrowUpCircle} label="Updates" />
                     <SidebarItem to="/logs" icon={FileText} label="Logs" />

--- a/admin_ui/frontend/src/pages/System/AsteriskPage.tsx
+++ b/admin_ui/frontend/src/pages/System/AsteriskPage.tsx
@@ -1,0 +1,378 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+    RefreshCw, CheckCircle2, XCircle, AlertCircle, Server, Wifi, WifiOff,
+    Copy, Check, Globe, Monitor, Clock, Package, AppWindow, FileText, Loader2
+} from 'lucide-react';
+import { ConfigSection } from '../../components/ui/ConfigSection';
+import { ConfigCard } from '../../components/ui/ConfigCard';
+import axios from 'axios';
+
+interface ManifestCheck {
+    ok: boolean;
+    detail: string;
+}
+
+interface Manifest {
+    timestamp: string;
+    asterisk_found: boolean;
+    asterisk_version: string;
+    config_dir: string;
+    freepbx: { detected: boolean; version: string };
+    checks: Record<string, ManifestCheck>;
+}
+
+interface LiveStatus {
+    ari_reachable: boolean;
+    asterisk_version: string | null;
+    uptime: string | null;
+    last_reload: string | null;
+    app_registered: boolean;
+    app_name: string;
+    modules: Record<string, string>;
+}
+
+interface AsteriskStatus {
+    mode: 'local' | 'remote';
+    manifest: Manifest | null;
+    live: LiveStatus;
+}
+
+const MODULE_DESCRIPTIONS: Record<string, string> = {
+    app_audiosocket: 'AudioSocket application for streaming audio',
+    res_ari: 'Asterisk REST Interface',
+    res_stasis: 'Stasis application framework',
+    chan_pjsip: 'PJSIP channel driver',
+    res_http_websocket: 'HTTP WebSocket support for ARI events',
+};
+
+const CONFIG_CHECK_LABELS: Record<string, { label: string; fixHint: string }> = {
+    ari_enabled: {
+        label: 'ARI Enabled',
+        fixHint: "Ensure 'enabled=yes' under [general] in /etc/asterisk/ari.conf or ari_general_custom.conf",
+    },
+    ari_user: {
+        label: 'ARI User Configured',
+        fixHint: 'Add an ARI user block in /etc/asterisk/ari_additional_custom.conf:\n\n[AIAgent]\ntype=user\npassword=YourPassword\nread_only=no',
+    },
+    http_enabled: {
+        label: 'HTTP Server Enabled',
+        fixHint: "Ensure 'enabled=yes' under [general] in /etc/asterisk/http.conf or http_custom.conf",
+    },
+    dialplan_context: {
+        label: 'Dialplan Context',
+        fixHint: 'Add a context in /etc/asterisk/extensions_custom.conf:\n\n[from-ai-agent]\nexten => s,1,NoOp(AI Agent)\n same => n,Stasis(asterisk-ai-voice-agent)\n same => n,Hangup()',
+    },
+};
+
+const CopyButton = ({ text }: { text: string }) => {
+    const [copied, setCopied] = useState(false);
+    const handleCopy = () => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+    return (
+        <button
+            onClick={handleCopy}
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            title="Copy to clipboard"
+        >
+            {copied ? <Check className="w-3 h-3 text-green-500" /> : <Copy className="w-3 h-3" />}
+            {copied ? 'Copied' : 'Copy'}
+        </button>
+    );
+};
+
+const StatusBadge = ({ ok, label }: { ok: boolean; label?: string }) => (
+    <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
+        ok ? 'bg-green-500/10 text-green-500' : 'bg-red-500/10 text-red-500'
+    }`}>
+        {ok ? <CheckCircle2 className="w-3 h-3" /> : <XCircle className="w-3 h-3" />}
+        {label || (ok ? 'OK' : 'Issue')}
+    </span>
+);
+
+const formatUptime = (isoStr: string | null): string => {
+    if (!isoStr) return '—';
+    try {
+        const start = new Date(isoStr);
+        const now = new Date();
+        const diffMs = now.getTime() - start.getTime();
+        const days = Math.floor(diffMs / 86400000);
+        const hours = Math.floor((diffMs % 86400000) / 3600000);
+        if (days > 0) return `${days}d ${hours}h`;
+        const mins = Math.floor((diffMs % 3600000) / 60000);
+        return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+    } catch {
+        return isoStr;
+    }
+};
+
+const AsteriskPage = () => {
+    const [status, setStatus] = useState<AsteriskStatus | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [expandedFixes, setExpandedFixes] = useState<Record<string, boolean>>({});
+
+    const fetchStatus = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await axios.get('/api/system/asterisk-status');
+            setStatus(res.data);
+        } catch (err: any) {
+            setError(err?.response?.data?.detail || err?.message || 'Failed to fetch Asterisk status');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => { fetchStatus(); }, [fetchStatus]);
+
+    const toggleFix = (key: string) => {
+        setExpandedFixes(prev => ({ ...prev, [key]: !prev[key] }));
+    };
+
+    if (loading && !status) {
+        return (
+            <div className="flex items-center justify-center min-h-[400px]">
+                <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+            </div>
+        );
+    }
+
+    if (error && !status) {
+        return (
+            <div className="p-6">
+                <div className="flex items-center gap-2 text-red-500 mb-4">
+                    <AlertCircle className="w-5 h-5" />
+                    <span>{error}</span>
+                </div>
+                <button onClick={fetchStatus} className="flex items-center gap-2 px-3 py-1.5 rounded bg-primary text-primary-foreground text-sm hover:opacity-90">
+                    <RefreshCw className="w-4 h-4" /> Retry
+                </button>
+            </div>
+        );
+    }
+
+    const live = status?.live;
+    const manifest = status?.manifest;
+    const mode = status?.mode || 'unknown';
+
+    return (
+        <div className="p-6 max-w-5xl mx-auto space-y-6">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                    <Server className="w-6 h-6 text-primary" />
+                    <div>
+                        <h1 className="text-2xl font-bold tracking-tight">Asterisk Setup</h1>
+                        <p className="text-sm text-muted-foreground">
+                            Configuration status and connectivity checks
+                        </p>
+                    </div>
+                    <span className={`ml-2 inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full ${
+                        mode === 'local'
+                            ? 'bg-blue-500/10 text-blue-500'
+                            : 'bg-purple-500/10 text-purple-500'
+                    }`}>
+                        {mode === 'local' ? <Monitor className="w-3 h-3" /> : <Globe className="w-3 h-3" />}
+                        {mode === 'local' ? 'Local' : 'Remote'}
+                    </span>
+                </div>
+                <button
+                    onClick={fetchStatus}
+                    disabled={loading}
+                    className="flex items-center gap-2 px-3 py-1.5 rounded-md border border-border text-sm hover:bg-accent transition-colors disabled:opacity-50"
+                >
+                    <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                    Refresh
+                </button>
+            </div>
+
+            {/* Connection Card */}
+            <ConfigSection title="ARI Connection" description="Live connection status to Asterisk REST Interface">
+                <ConfigCard>
+                    <div className="flex items-center gap-3 mb-4">
+                        {live?.ari_reachable ? (
+                            <Wifi className="w-5 h-5 text-green-500" />
+                        ) : (
+                            <WifiOff className="w-5 h-5 text-red-500" />
+                        )}
+                        <span className={`text-lg font-semibold ${live?.ari_reachable ? 'text-green-500' : 'text-red-500'}`}>
+                            {live?.ari_reachable ? 'Connected' : 'Not Reachable'}
+                        </span>
+                    </div>
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                        <div>
+                            <span className="text-muted-foreground">Version</span>
+                            <p className="font-medium">{live?.asterisk_version || '—'}</p>
+                        </div>
+                        <div>
+                            <span className="text-muted-foreground">Uptime</span>
+                            <p className="font-medium">{formatUptime(live?.uptime || null)}</p>
+                        </div>
+                        <div>
+                            <span className="text-muted-foreground">Last Reload</span>
+                            <p className="font-medium">{live?.last_reload ? new Date(live.last_reload).toLocaleString() : '—'}</p>
+                        </div>
+                        <div>
+                            <span className="text-muted-foreground">Mode</span>
+                            <p className="font-medium capitalize">{mode}</p>
+                        </div>
+                    </div>
+                    {manifest?.freepbx?.detected && (
+                        <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+                            <FileText className="w-4 h-4" />
+                            FreePBX {manifest.freepbx.version || 'detected'}
+                            {manifest.config_dir && <span className="ml-2">({manifest.config_dir})</span>}
+                        </div>
+                    )}
+                </ConfigCard>
+            </ConfigSection>
+
+            {/* Modules Checklist */}
+            <ConfigSection title="Required Modules" description="Asterisk modules needed for the AI Voice Agent">
+                <ConfigCard>
+                    {live?.ari_reachable && Object.keys(live.modules).length > 0 ? (
+                        <div className="divide-y divide-border">
+                            {Object.entries(live.modules).map(([mod, moduleStatus]) => {
+                                const isRunning = moduleStatus === 'Running';
+                                return (
+                                    <div key={mod} className="flex items-center justify-between py-2.5 first:pt-0 last:pb-0">
+                                        <div className="flex items-center gap-3">
+                                            <Package className="w-4 h-4 text-muted-foreground" />
+                                            <div>
+                                                <span className="text-sm font-medium">{mod}.so</span>
+                                                <p className="text-xs text-muted-foreground">
+                                                    {MODULE_DESCRIPTIONS[mod] || ''}
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <StatusBadge ok={isRunning} label={moduleStatus} />
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    ) : !live?.ari_reachable ? (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <AlertCircle className="w-4 h-4" />
+                            Module checks require an active ARI connection
+                        </div>
+                    ) : (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                            Checking modules...
+                        </div>
+                    )}
+                </ConfigCard>
+            </ConfigSection>
+
+            {/* App Registration */}
+            <ConfigSection title="Application Registration" description="Whether the ARI application is registered and listening">
+                <ConfigCard>
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                            <AppWindow className="w-4 h-4 text-muted-foreground" />
+                            <div>
+                                <span className="text-sm font-medium">{live?.app_name || 'asterisk-ai-voice-agent'}</span>
+                                <p className="text-xs text-muted-foreground">Stasis application</p>
+                            </div>
+                        </div>
+                        {live?.ari_reachable ? (
+                            <StatusBadge ok={live?.app_registered || false} label={live?.app_registered ? 'Registered' : 'Not Registered'} />
+                        ) : (
+                            <span className="text-xs text-muted-foreground">Requires ARI connection</span>
+                        )}
+                    </div>
+                    {live?.ari_reachable && !live?.app_registered && (
+                        <div className="mt-3 p-3 rounded-md bg-amber-500/5 border border-amber-500/20 text-sm text-amber-600 dark:text-amber-400">
+                            The AI Engine must be running and connected to Asterisk for the app to be registered.
+                            Start the ai_engine container to register the application.
+                        </div>
+                    )}
+                </ConfigCard>
+            </ConfigSection>
+
+            {/* Configuration Checklist (from manifest) */}
+            <ConfigSection title="Configuration Checklist" description="Asterisk config file checks from the last preflight run">
+                <ConfigCard>
+                    {manifest && manifest.checks && Object.keys(manifest.checks).length > 0 ? (
+                        <div className="divide-y divide-border">
+                            {Object.entries(manifest.checks).map(([key, check]) => {
+                                const meta = CONFIG_CHECK_LABELS[key];
+                                const label = meta?.label || key.replace(/_/g, ' ').replace(/^module /, '');
+                                const isModule = key.startsWith('module_');
+                                return (
+                                    <div key={key} className="py-2.5 first:pt-0 last:pb-0">
+                                        <div className="flex items-center justify-between">
+                                            <div className="flex items-center gap-3">
+                                                {isModule ? (
+                                                    <Package className="w-4 h-4 text-muted-foreground" />
+                                                ) : (
+                                                    <FileText className="w-4 h-4 text-muted-foreground" />
+                                                )}
+                                                <div>
+                                                    <span className="text-sm font-medium">{label}</span>
+                                                    <p className="text-xs text-muted-foreground">{check.detail}</p>
+                                                </div>
+                                            </div>
+                                            <div className="flex items-center gap-2">
+                                                <StatusBadge ok={check.ok} />
+                                                {!check.ok && meta?.fixHint && (
+                                                    <button
+                                                        onClick={() => toggleFix(key)}
+                                                        className="text-xs text-primary hover:underline"
+                                                    >
+                                                        {expandedFixes[key] ? 'Hide fix' : 'How to fix'}
+                                                    </button>
+                                                )}
+                                            </div>
+                                        </div>
+                                        {!check.ok && meta?.fixHint && expandedFixes[key] && (
+                                            <div className="mt-2 ml-7">
+                                                <div className="relative">
+                                                    <pre className="p-3 rounded-md bg-muted text-xs font-mono whitespace-pre-wrap overflow-x-auto">
+                                                        {meta.fixHint}
+                                                    </pre>
+                                                    <div className="absolute top-2 right-2">
+                                                        <CopyButton text={meta.fixHint} />
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    ) : manifest === null ? (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <AlertCircle className="w-4 h-4" />
+                            <div>
+                                <p>No preflight manifest found.</p>
+                                <p className="mt-1">Run <code className="px-1.5 py-0.5 rounded bg-muted text-xs font-mono">./preflight.sh</code> on the host to generate it.</p>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <CheckCircle2 className="w-4 h-4 text-green-500" />
+                            No configuration issues detected
+                        </div>
+                    )}
+                </ConfigCard>
+            </ConfigSection>
+
+            {/* Manifest Info */}
+            {manifest && (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Clock className="w-3 h-3" />
+                    Last preflight run: {manifest.timestamp ? new Date(manifest.timestamp).toLocaleString() : 'unknown'}
+                    <span className="ml-2">•</span>
+                    <span>Run <code className="px-1 py-0.5 rounded bg-muted font-mono">./preflight.sh</code> on the host to refresh</span>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default AsteriskPage;

--- a/preflight.sh
+++ b/preflight.sh
@@ -1866,6 +1866,182 @@ check_asterisk_uid_gid() {
 }
 
 # ============================================================================
+# Asterisk Config Audit → JSON Manifest (AAVA: Asterisk Config Discovery)
+# ============================================================================
+check_asterisk_config() {
+    # Only run if Asterisk was detected on host
+    if [ "$ASTERISK_FOUND" != true ] || [ -z "$ASTERISK_DIR" ]; then
+        log_info "Asterisk config audit skipped (not detected on host)"
+        # Write minimal manifest so the UI knows preflight ran
+        _write_asterisk_manifest false "" "" false "" "{}"
+        return 0
+    fi
+
+    local APP_NAME
+    APP_NAME="$(grep -E '^[[:space:]]*app_name:' "$SCRIPT_DIR/config/ai-agent.yaml" 2>/dev/null | head -1 | sed 's/.*app_name:[[:space:]]*//' | tr -d '\r\n"'"'" || echo "asterisk-ai-voice-agent")"
+    [ -z "$APP_NAME" ] && APP_NAME="asterisk-ai-voice-agent"
+
+    local FREEPBX_DETECTED=false
+    local FREEPBX_VER=""
+    if [ -f "/etc/freepbx.conf" ] || [ -f "/etc/sangoma/pbx" ]; then
+        FREEPBX_DETECTED=true
+        FREEPBX_VER=$(fwconsole -V 2>/dev/null | head -1 || echo "detected")
+    fi
+
+    # --- ARI enabled check ---
+    local ari_enabled_ok=false
+    local ari_enabled_detail="not found"
+    # FreePBX splits config via #include; check both main and included files
+    for f in "$ASTERISK_DIR/ari.conf" "$ASTERISK_DIR/ari_general_additional.conf" "$ASTERISK_DIR/ari_general_custom.conf"; do
+        if [ -f "$f" ] && grep -qiE '^[[:space:]]*enabled[[:space:]]*=[[:space:]]*yes' "$f" 2>/dev/null; then
+            ari_enabled_ok=true
+            ari_enabled_detail="enabled=yes in $(basename "$f")"
+            break
+        fi
+    done
+    if [ "$ari_enabled_ok" = true ]; then
+        log_ok "ARI enabled: $ari_enabled_detail"
+    else
+        log_warn "ARI not enabled in ari.conf (or included files)"
+        log_info "  Fix: ensure 'enabled=yes' under [general] in ari.conf or ari_general_custom.conf"
+    fi
+
+    # --- ARI user check ---
+    local ari_user_ok=false
+    local ari_user_detail="not found"
+    local ARI_USERNAME="${ASTERISK_ARI_USERNAME:-}"
+    [ -z "$ARI_USERNAME" ] && ARI_USERNAME="$(grep -E '^ASTERISK_ARI_USERNAME=' "$SCRIPT_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '\r\n"'"'" || true)"
+    [ -z "$ARI_USERNAME" ] && ARI_USERNAME="AIAgent"
+    for f in "$ASTERISK_DIR/ari.conf" "$ASTERISK_DIR/ari_additional.conf" "$ASTERISK_DIR/ari_additional_custom.conf"; do
+        if [ -f "$f" ] && grep -qE "^\[$ARI_USERNAME\]" "$f" 2>/dev/null; then
+            ari_user_ok=true
+            ari_user_detail="[$ARI_USERNAME] found in $(basename "$f")"
+            break
+        fi
+    done
+    if [ "$ari_user_ok" = true ]; then
+        log_ok "ARI user: $ari_user_detail"
+    else
+        log_warn "ARI user [$ARI_USERNAME] not found in ari.conf (or included files)"
+        log_info "  Fix: add user block in ari_additional_custom.conf or via FreePBX Admin"
+    fi
+
+    # --- HTTP enabled check ---
+    local http_enabled_ok=false
+    local http_enabled_detail="not found"
+    for f in "$ASTERISK_DIR/http.conf" "$ASTERISK_DIR/http_additional.conf" "$ASTERISK_DIR/http_custom.conf"; do
+        if [ -f "$f" ] && grep -qiE '^[[:space:]]*enabled[[:space:]]*=[[:space:]]*yes' "$f" 2>/dev/null; then
+            http_enabled_ok=true
+            http_enabled_detail="enabled=yes in $(basename "$f")"
+            break
+        fi
+    done
+    if [ "$http_enabled_ok" = true ]; then
+        log_ok "HTTP server: $http_enabled_detail"
+    else
+        log_warn "HTTP server not enabled in http.conf (or included files)"
+        log_info "  Fix: ensure 'enabled=yes' under [general] in http.conf or http_custom.conf"
+    fi
+
+    # --- Dialplan context check ---
+    local dialplan_ok=false
+    local dialplan_detail="not found"
+    if [ -f "$ASTERISK_DIR/extensions_custom.conf" ]; then
+        if grep -qiE "Stasis\($APP_NAME\)" "$ASTERISK_DIR/extensions_custom.conf" 2>/dev/null; then
+            dialplan_ok=true
+            dialplan_detail="Stasis($APP_NAME) in extensions_custom.conf"
+        fi
+    fi
+    if [ "$dialplan_ok" = true ]; then
+        log_ok "Dialplan context: $dialplan_detail"
+    else
+        log_warn "No Stasis($APP_NAME) context found in extensions_custom.conf"
+        log_info "  Fix: add a context with 'Stasis($APP_NAME)' to extensions_custom.conf"
+    fi
+
+    # --- Module checks (requires asterisk binary) ---
+    local mod_audiosocket_ok=false mod_audiosocket_detail="binary not available"
+    local mod_res_ari_ok=false mod_res_ari_detail="binary not available"
+    local mod_res_stasis_ok=false mod_res_stasis_detail="binary not available"
+    local mod_chan_pjsip_ok=false mod_chan_pjsip_detail="binary not available"
+
+    if command -v asterisk &>/dev/null; then
+        _check_ast_module "app_audiosocket" && mod_audiosocket_ok=true && mod_audiosocket_detail="Running"
+        [ "$mod_audiosocket_ok" = false ] && mod_audiosocket_detail="Not loaded"
+
+        _check_ast_module "res_ari" && mod_res_ari_ok=true && mod_res_ari_detail="Running"
+        [ "$mod_res_ari_ok" = false ] && mod_res_ari_detail="Not loaded"
+
+        _check_ast_module "res_stasis" && mod_res_stasis_ok=true && mod_res_stasis_detail="Running"
+        [ "$mod_res_stasis_ok" = false ] && mod_res_stasis_detail="Not loaded"
+
+        _check_ast_module "chan_pjsip" && mod_chan_pjsip_ok=true && mod_chan_pjsip_detail="Running"
+        [ "$mod_chan_pjsip_ok" = false ] && mod_chan_pjsip_detail="Not loaded"
+
+        log_ok "Asterisk modules: audiosocket=$mod_audiosocket_detail, res_ari=$mod_res_ari_detail, res_stasis=$mod_res_stasis_detail, chan_pjsip=$mod_chan_pjsip_detail"
+    else
+        log_info "Asterisk binary not in PATH — module checks skipped (will use ARI in Admin UI)"
+    fi
+
+    # --- Build JSON checks object ---
+    local CHECKS
+    CHECKS=$(cat <<JSONEOF
+{
+    "ari_enabled": { "ok": $ari_enabled_ok, "detail": "$ari_enabled_detail" },
+    "ari_user": { "ok": $ari_user_ok, "detail": "$ari_user_detail" },
+    "http_enabled": { "ok": $http_enabled_ok, "detail": "$http_enabled_detail" },
+    "dialplan_context": { "ok": $dialplan_ok, "detail": "$dialplan_detail" },
+    "module_app_audiosocket": { "ok": $mod_audiosocket_ok, "detail": "$mod_audiosocket_detail" },
+    "module_res_ari": { "ok": $mod_res_ari_ok, "detail": "$mod_res_ari_detail" },
+    "module_res_stasis": { "ok": $mod_res_stasis_ok, "detail": "$mod_res_stasis_detail" },
+    "module_chan_pjsip": { "ok": $mod_chan_pjsip_ok, "detail": "$mod_chan_pjsip_detail" }
+}
+JSONEOF
+    )
+
+    _write_asterisk_manifest true "${ASTERISK_VERSION:-unknown}" "$ASTERISK_DIR" "$FREEPBX_DETECTED" "$FREEPBX_VER" "$CHECKS"
+}
+
+# Helper: check if an Asterisk module is loaded via CLI
+_check_ast_module() {
+    local mod_name="$1"
+    local output
+    output=$(asterisk -rx "module show like $mod_name" 2>/dev/null || true)
+    echo "$output" | grep -qiE "$mod_name.*Running"
+}
+
+# Helper: write the JSON manifest to data/asterisk_status.json
+_write_asterisk_manifest() {
+    local ast_found="$1" ast_version="$2" config_dir="$3" fpbx_detected="$4" fpbx_version="$5" checks_json="$6"
+    local MANIFEST_DIR="$SCRIPT_DIR/data"
+    local MANIFEST_FILE="$MANIFEST_DIR/asterisk_status.json"
+    local TIMESTAMP
+    TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +"%Y-%m-%dT%H:%M:%SZ")"
+
+    mkdir -p "$MANIFEST_DIR" 2>/dev/null || true
+
+    cat > "$MANIFEST_FILE" <<MANIFESTEOF
+{
+    "timestamp": "$TIMESTAMP",
+    "asterisk_found": $ast_found,
+    "asterisk_version": "$ast_version",
+    "config_dir": "$config_dir",
+    "freepbx": {
+        "detected": $fpbx_detected,
+        "version": "$fpbx_version"
+    },
+    "checks": $checks_json
+}
+MANIFESTEOF
+
+    if [ -f "$MANIFEST_FILE" ]; then
+        log_ok "Asterisk config manifest: $MANIFEST_FILE"
+    else
+        log_warn "Could not write Asterisk config manifest to $MANIFEST_FILE"
+    fi
+}
+
+# ============================================================================
 # GPU Detection (AAVA-140)
 # ============================================================================
 check_gpu() {
@@ -2232,6 +2408,7 @@ main() {
     check_docker_gid
     check_asterisk
     check_asterisk_uid_gid
+    check_asterisk_config
     check_gpu
     check_ports
     


### PR DESCRIPTION
## Summary

Adds Asterisk configuration discovery and status monitoring to the Admin UI (Phases 1+2 of the Asterisk Config UI plan).

### Phase 1: Preflight Audit
- New `check_asterisk_config()` in `preflight.sh` audits `ari.conf`, `http.conf`, `extensions_custom.conf`, and 4 key Asterisk modules
- Writes JSON manifest to `data/asterisk_status.json`
- Checks FreePBX include files (`ari_additional.conf`, `ari_general_additional.conf`, etc.)
- Gracefully skips when Asterisk is remote (writes minimal manifest)

### Phase 2: Admin UI Status Page
- **Backend**: `GET /api/system/asterisk-status` reads preflight manifest + performs live ARI checks (info, modules, app registration)
- **Frontend**: New `AsteriskPage.tsx` with:
  - Connection card (ARI status, version, uptime, last reload)
  - Modules checklist (5 required modules with live status)
  - Configuration checklist from manifest with expandable "How to fix" copy-paste snippets
  - App registration status
  - Local/Remote mode badge
- **Dashboard**: Clickable Asterisk connection pill (green/red)
- **Sidebar**: Asterisk entry under System group

### Files Changed
| File | Change |
|---|---|
| `preflight.sh` | +177 lines — `check_asterisk_config()` + helpers |
| `admin_ui/backend/api/system.py` | +137 lines — `GET /api/system/asterisk-status` |
| `admin_ui/frontend/src/pages/System/AsteriskPage.tsx` | New (378 lines) |
| `admin_ui/frontend/src/App.tsx` | +2 lines — lazy route |
| `admin_ui/frontend/src/components/layout/Sidebar.tsx` | +1 line — nav item |
| `admin_ui/frontend/src/pages/Dashboard.tsx` | +36 lines — Asterisk pill + fetch |

### Testing
- ✅ Preflight: all 8 checks pass on staging (ARI enabled, ARI user, HTTP, dialplan, 4 modules)
- ✅ Backend: `/api/system/asterisk-status` returns 200 with live ARI data
- ✅ Frontend: page loads, modules/config checklist renders, Dashboard pill works
- ✅ Deployed and verified on staging server

### Phase 3 (Deferred to v6.2.0)
One-click auto-fix for config files deferred — requires `/etc/asterisk` mount + permission model changes. Phase 2 includes guided copy-paste commands as an interim solution.
