### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,7 +150,7 @@ TELNYX_API_KEY=
 # MiniMax LLM (OpenAI-compatible API)
 # Get your API key at: https://platform.minimax.io/
 # Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
-# Models: MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context)
+# Models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
 MINIMAX_API_KEY=
 
 # Microsoft Azure Speech Service (STT & TTS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Microsoft Azure Speech Service STT & TTS**: Full modular pipeline support with three adapters — `AzureSTTFastAdapter` (REST batch transcription), `AzureSTTRealtimeAdapter` (WebSocket streaming with VAD), and `AzureTTSAdapter` (SSML synthesis with streaming and non-streaming modes). Includes Admin UI forms, quick-add templates, security key injection, A-law/μ-law passthrough, and validated config in `ai-agent.yaml`. Contributed by [@egorky](https://github.com/egorky).
-- **MiniMax LLM Pipeline Adapter**: New LLM provider supporting MiniMax M2.5 models with 204K context window via OpenAI-compatible API. Includes tool-calling support, Admin UI integration, and full test suite. Contributed by [@octo-patch](https://github.com/octo-patch).
+- **MiniMax LLM Pipeline Adapter**: New LLM provider supporting MiniMax M2.7 models (latest flagship with enhanced reasoning and coding) via OpenAI-compatible API. Includes tool-calling support, Admin UI integration, and full test suite. Contributed by [@octo-patch](https://github.com/octo-patch).
 - **Call Recording Playback**: Play back Asterisk/FreePBX call recordings directly from the Call Details modal in the Admin UI. Recordings are auto-matched by channel unique ID from the monitor directory (`YYYY/MM/DD/` layout). Includes play/pause controls, seek bar, time display, filename, and file size. Empty WAV files (header-only) are shown as "no audio captured". Configurable via `ASTERISK_RECORDING_PATH` env var.
 - **Google Calendar delete()**: Full delete event implementation with timezone handling fixes and code quality improvements. Contributed by [@gcsuri](https://github.com/gcsuri).
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ docker compose -p asterisk-ai-voice-agent logs -f ai_engine
 
 ### ☁️ New Providers (v6.3.2)
 - **Microsoft Azure Speech Service**: Full modular STT & TTS pipeline adapters — Fast REST batch, Realtime WebSocket with VAD, and SSML synthesis with streaming. Admin UI forms, quick-add templates, and security key injection.
-- **MiniMax LLM**: M2.5 models with 204K context window via OpenAI-compatible API. Tool-calling support and Admin UI integration.
+- **MiniMax LLM**: M2.7 models (latest flagship with enhanced reasoning and coding) via OpenAI-compatible API. Tool-calling support and Admin UI integration.
 
 ### 🎧 Admin UI (v6.3.2)
 - **Call Recording Playback**: Play back Asterisk call recordings directly from the Call Details modal, auto-matched by channel unique ID.
@@ -283,9 +283,9 @@ For full release notes, see [CHANGELOG.md](CHANGELOG.md).
 ### Additional LLM Providers
 
 - **MiniMax LLM** (High-Performance Cost-Effective)
-   - Local STT/TTS + MiniMax M2.5 LLM with 204K context window.
+   - Local STT/TTS + MiniMax M2.7 LLM with enhanced reasoning and coding.
    - OpenAI-compatible API with tool-calling support.
-   - Models: `MiniMax-M2.5` (peak performance) and `MiniMax-M2.5-highspeed` (faster).
+   - Models: `MiniMax-M2.7` (default, latest flagship), `MiniMax-M2.7-highspeed` (low-latency), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
    - Activate: set `MINIMAX_API_KEY` in `.env`, then configure `providers.minimax_llm` in `config/ai-agent.yaml` (see the `minimax_llm` section with `enabled: true`).
    - *Best for: Long-context conversations, cost-effective high-performance LLM.*
 

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -1526,8 +1526,8 @@ providers:
       - llm
     chat_base_url: https://api.minimax.io/v1
     # Domestic (China) URL: https://api.minimaxi.com/v1
-    chat_model: MiniMax-M2.5
-    # Alternative: MiniMax-M2.5-highspeed (same performance, faster)
+    chat_model: MiniMax-M2.7
+    # Alternatives: MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
     enabled: false
     # API key comes from MINIMAX_API_KEY env var
     temperature: 1.0

--- a/docs/Provider-MiniMax-Setup.md
+++ b/docs/Provider-MiniMax-Setup.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-MiniMax provides OpenAI-compatible Chat Completions for its M2.5 family of models with 204K context windows. Suitable for AI voice agents needing large-context LLM capabilities with tool calling support.
+MiniMax provides OpenAI-compatible Chat Completions for its M2.7 family of models with enhanced reasoning and coding capabilities. Suitable for AI voice agents needing large-context LLM capabilities with tool calling support.
 
 **Performance**: 204K context window | OpenAI-compatible API | Tool calling supported
 
 **Why MiniMax?**
 - **Large context**: 204K token context window for complex conversations
 - **OpenAI-compatible**: Standard Chat Completions API format
-- **Speed option**: `MiniMax-M2.5-highspeed` variant for latency-sensitive calls
+- **Speed option**: `MiniMax-M2.7-highspeed` variant for latency-sensitive calls
 - **Tool calling**: Native function calling via OpenAI-style `tools` parameter
 
 If you used the Admin UI Setup Wizard, you may not need to follow this guide end-to-end. For first-call onboarding and transport selection, see:
@@ -50,7 +50,7 @@ providers:
     capabilities: [llm]
     chat_base_url: "https://api.minimax.io/v1"
     # For China domestic access: https://api.minimaxi.com/v1
-    chat_model: MiniMax-M2.5
+    chat_model: MiniMax-M2.7
     temperature: 1.0
     response_timeout_sec: 30
 
@@ -61,7 +61,7 @@ pipelines:
     tts: local_tts
     options:
       llm:
-        model: MiniMax-M2.5
+        model: MiniMax-M2.7
         temperature: 1.0
         max_tokens: 150
       stt:
@@ -81,8 +81,10 @@ active_pipeline: minimax_hybrid
 
 | Model | Description | Best For |
 |-------|-------------|----------|
-| `MiniMax-M2.5` | Default, 204K context | General-purpose voice workflows |
-| `MiniMax-M2.5-highspeed` | Same performance, lower latency | Latency-sensitive calls |
+| `MiniMax-M2.7` | Default, latest flagship with enhanced reasoning | General-purpose voice workflows |
+| `MiniMax-M2.7-highspeed` | High-speed version of M2.7 | Latency-sensitive calls |
+| `MiniMax-M2.5` | Previous generation, 204K context | Legacy compatibility |
+| `MiniMax-M2.5-highspeed` | Previous generation, lower latency | Legacy latency-sensitive calls |
 
 ### 5. Tool Calling
 
@@ -119,7 +121,7 @@ asterisk -rx "dialplan reload"
 1. Navigate to the Admin UI provider configuration page
 2. Add a new LLM provider with type `minimax`
 3. Set the API key (or reference `MINIMAX_API_KEY` from `.env`)
-4. Select model (`MiniMax-M2.5` or `MiniMax-M2.5-highspeed`)
+4. Select model (`MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, or `MiniMax-M2.5-highspeed`)
 5. Create or update a pipeline to use `minimax_llm` as the LLM component
 
 ### 9. Test Call
@@ -150,7 +152,7 @@ Route a test call to the custom destination and verify:
 
 ### Issue: High latency
 
-**Fix**: Switch to `MiniMax-M2.5-highspeed` for faster responses. Reduce `max_tokens` if responses are longer than needed.
+**Fix**: Switch to `MiniMax-M2.7-highspeed` for faster responses. Reduce `max_tokens` if responses are longer than needed.
 
 ## See Also
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@
 - **[ElevenLabs Agent Setup](Provider-ElevenLabs-Setup.md)** - ElevenLabs Conversational AI with premium voices
 - **[Telnyx AI Inference Setup](Provider-Telnyx-Setup.md)** - OpenAI-compatible LLM via Telnyx
 - **[Azure Speech Service Setup](Provider-Azure-Setup.md)** - Azure STT & TTS pipeline adapters
-- **[MiniMax LLM Setup](Provider-MiniMax-Setup.md)** - MiniMax M2.5 LLM via OpenAI-compatible API
+- **[MiniMax LLM Setup](Provider-MiniMax-Setup.md)** - MiniMax M2.7 LLM via OpenAI-compatible API
 
 ## Local AI & GPU Setup
 

--- a/src/config.py
+++ b/src/config.py
@@ -235,7 +235,8 @@ class MiniMaxLLMProviderConfig(BaseModel):
     Canonical defaults for the MiniMax LLM pipeline adapter.
 
     MiniMax exposes an OpenAI-compatible Chat Completions endpoint.
-    Supported models: MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context).
+    Supported models: MiniMax-M2.7, MiniMax-M2.7-highspeed,
+    MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context).
 
     Key constraints:
       - temperature must be in (0.0, 1.0]; 0 is rejected.
@@ -247,7 +248,7 @@ class MiniMaxLLMProviderConfig(BaseModel):
     api_key: Optional[str] = None
 
     chat_base_url: str = Field(default="https://api.minimax.io/v1")
-    chat_model: str = Field(default="MiniMax-M2.5")
+    chat_model: str = Field(default="MiniMax-M2.7")
 
     temperature: float = Field(default=1.0)
     max_tokens: Optional[int] = None

--- a/src/pipelines/minimax.py
+++ b/src/pipelines/minimax.py
@@ -1,13 +1,15 @@
 """
 MiniMax LLM pipeline adapter (OpenAI-compatible Chat Completions).
 
-MiniMax provides OpenAI-compatible endpoints for its M2.5 family of models.
+MiniMax provides OpenAI-compatible endpoints for its M2.7 family of models.
 This adapter uses the OpenAI Chat Completions format with MiniMax-specific
 constraints (e.g. temperature must be in (0.0, 1.0], response_format unsupported).
 
 Supported models:
-  - MiniMax-M2.5        (default, 204K context)
-  - MiniMax-M2.5-highspeed  (same performance, faster)
+  - MiniMax-M2.7            (default, latest flagship with enhanced reasoning)
+  - MiniMax-M2.7-highspeed  (high-speed version for low-latency scenarios)
+  - MiniMax-M2.5            (previous generation, 204K context)
+  - MiniMax-M2.5-highspeed  (previous generation, faster)
 
 API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
 """

--- a/tests/test_pipeline_minimax_adapter.py
+++ b/tests/test_pipeline_minimax_adapter.py
@@ -19,7 +19,7 @@ def _build_app_config() -> AppConfig:
         "minimax_llm": {
             "api_key": "test-minimax-key",
             "chat_base_url": "https://api.minimax.io/v1",
-            "chat_model": "MiniMax-M2.5",
+            "chat_model": "MiniMax-M2.7",
             "temperature": 1.0,
             "response_timeout_sec": 10.0,
             "type": "minimax",
@@ -39,7 +39,7 @@ def _build_app_config() -> AppConfig:
         default_provider="minimax",
         providers=providers,
         asterisk={"host": "127.0.0.1", "username": "ari", "password": "secret"},
-        llm={"initial_greeting": "hi", "prompt": "You are a helpful assistant.", "model": "MiniMax-M2.5"},
+        llm={"initial_greeting": "hi", "prompt": "You are a helpful assistant.", "model": "MiniMax-M2.7"},
         audio_transport="audiosocket",
         downstream_mode="stream",
         pipelines=pipelines,
@@ -158,7 +158,7 @@ async def test_minimax_llm_chat_completion():
     assert response.tool_calls == []
 
     request = fake_session.requests[0]
-    assert request["json"]["model"] == "MiniMax-M2.5"
+    assert request["json"]["model"] == "MiniMax-M2.7"
     assert request["url"] == "https://api.minimax.io/v1/chat/completions"
     assert request["headers"]["Authorization"] == "Bearer test-minimax-key"
 
@@ -248,10 +248,10 @@ async def test_minimax_llm_strips_thinking():
 
 @pytest.mark.asyncio
 async def test_minimax_llm_highspeed_model():
-    """Adapter works with the MiniMax-M2.5-highspeed model."""
+    """Adapter works with the MiniMax-M2.7-highspeed model."""
     app_config = _build_app_config()
     config_data = dict(app_config.providers["minimax_llm"])
-    config_data["chat_model"] = "MiniMax-M2.5-highspeed"
+    config_data["chat_model"] = "MiniMax-M2.7-highspeed"
     provider_config = MiniMaxLLMProviderConfig(**config_data)
     body = json.dumps({
         "choices": [{"message": {"content": "fast response"}}],
@@ -268,7 +268,7 @@ async def test_minimax_llm_highspeed_model():
     await adapter.start()
     response = await adapter.generate("call-1", "hi", {}, {})
     assert response.text == "fast response"
-    assert fake_session.requests[0]["json"]["model"] == "MiniMax-M2.5-highspeed"
+    assert fake_session.requests[0]["json"]["model"] == "MiniMax-M2.7-highspeed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M2.7 model as default.

## Changes
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to the model selection list
- Set MiniMax-M2.7 as the new default model
- Retain all previous models (M2.5, M2.5-highspeed) as available alternatives
- Update config, docs, tests, and examples

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

## Files Changed (9)
- `src/config.py` — Default model updated to M2.7
- `src/pipelines/minimax.py` — Docstring updated with new model list
- `config/ai-agent.yaml` — Default chat_model updated
- `tests/test_pipeline_minimax_adapter.py` — Tests updated for M2.7
- `README.md` — Model list updated
- `docs/Provider-MiniMax-Setup.md` — Full docs updated
- `.env.example` — Model comment updated
- `CHANGELOG.md` — Version note updated
- `docs/README.md` — Reference updated

## Testing
- Unit tests updated and passing
- Default model verified as MiniMax-M2.7
- Backward compatibility confirmed (M2.5 models still work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MiniMax LLM model upgraded to M2.7 with enhanced reasoning and improved coding capabilities
  * New M2.7-highspeed variant available for lower-latency use cases
  * Continued support for M2.5 variants maintains backward compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->