### PR TITLE
feat: add CAMB AI as TTS provider option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,6 +143,7 @@ OPENAI_API_KEY=
 DEEPGRAM_API_KEY=
 GOOGLE_API_KEY=
 ELEVENLABS_API_KEY=
+CAMB_API_KEY=
 
 # Telnyx AI Inference (OpenAI-compatible API for LLM)
 # Get your API key at: https://portal.telnyx.com/

--- a/admin_ui/backend/api/wizard.py
+++ b/admin_ui/backend/api/wizard.py
@@ -2790,7 +2790,33 @@ async def validate_api_key(validation: ApiKeyValidation):
                         return {"valid": False, "error": error_msg}
                     else:
                         return {"valid": False, "error": f"API error: HTTP {response.status_code}"}
-            
+
+            elif provider == "cambai":
+                # Validate CAMB AI key by performing a tiny TTS request.
+                # The /tts-stream endpoint returns 200 + audio bytes for a valid key,
+                # 401/403 for invalid keys.
+                response = await client.post(
+                    "https://client.camb.ai/apis/tts-stream",
+                    headers={
+                        "x-api-key": api_key,
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "text": "test",
+                        "voice_id": 147320,
+                        "language": "en-us",
+                        "speech_model": "mars-flash",
+                        "output_configuration": {"format": "pcm_s16le"},
+                    },
+                    timeout=15.0,
+                )
+                if response.status_code == 200:
+                    return {"valid": True, "message": "CAMB AI API key is valid"}
+                elif response.status_code in (401, 403):
+                    return {"valid": False, "error": "Invalid API key"}
+                else:
+                    return {"valid": False, "error": f"API error: HTTP {response.status_code}"}
+
             else:
                 return {"valid": False, "error": f"Unknown provider: {provider}"}
                 
@@ -2904,6 +2930,7 @@ class SetupConfig(BaseModel):
     elevenlabs_key: Optional[str] = None
     elevenlabs_agent_id: Optional[str] = None
     cartesia_key: Optional[str] = None
+    camb_key: Optional[str] = None
     greeting: str
     ai_name: str
     ai_role: str
@@ -2951,6 +2978,13 @@ async def save_setup_config(config: SetupConfig):
             raise HTTPException(status_code=400, detail="ElevenLabs API Key is required for ElevenLabs Conversational provider")
         if not config.elevenlabs_agent_id:
             raise HTTPException(status_code=400, detail="ElevenLabs Agent ID is required for ElevenLabs Conversational provider")
+    if config.provider == "cambai":
+        if not config.camb_key:
+            raise HTTPException(status_code=400, detail="CAMB AI API Key is required for CAMB AI provider")
+        if not config.deepgram_key:
+            raise HTTPException(status_code=400, detail="Deepgram API Key is required for CAMB AI pipeline (STT)")
+        if not config.openai_key:
+            raise HTTPException(status_code=400, detail="OpenAI API Key is required for CAMB AI pipeline (LLM)")
 
     try:
         import shutil
@@ -2992,6 +3026,8 @@ async def save_setup_config(config: SetupConfig):
             env_updates["ELEVENLABS_AGENT_ID"] = config.elevenlabs_agent_id
         if config.cartesia_key:
             env_updates["CARTESIA_API_KEY"] = config.cartesia_key
+        if config.camb_key:
+            env_updates["CAMB_API_KEY"] = config.camb_key
 
         if config.provider in ("local", "local_hybrid"):
             catalog = get_full_catalog()
@@ -3314,6 +3350,52 @@ async def save_setup_config(config: SetupConfig):
                     "stt": "local_stt",
                     "llm": llm_component,
                     "tts": "local_tts"
+                }
+
+            elif config.provider == "cambai":
+                # CAMB AI is a TTS-only provider, so it runs as a PIPELINE:
+                # Deepgram STT + OpenAI LLM + CAMB AI TTS
+                pipeline_name = "cambai_pipeline"
+                yaml_config["active_pipeline"] = pipeline_name
+                yaml_config["default_provider"] = pipeline_name
+
+                # Configure CAMB AI TTS provider
+                providers.setdefault("cambai", {})["enabled"] = True
+                if not provider_exists("cambai"):
+                    providers["cambai"].update({
+                        "voice_id": 147320,
+                        "speech_model": "mars-flash",
+                        "language": "en-us",
+                        "output_format": "pcm_s16le",
+                    })
+
+                # Configure Deepgram STT pipeline adapter
+                providers.setdefault("deepgram_stt", {})["enabled"] = True
+                if not provider_exists("deepgram_stt"):
+                    providers["deepgram_stt"].update({
+                        "api_key": "${DEEPGRAM_API_KEY}",
+                        "model": "nova-2-general",
+                        "stt_language": "en-US",
+                        "input_encoding": "linear16",
+                        "input_sample_rate_hz": 8000,
+                    })
+
+                # Configure OpenAI LLM pipeline adapter
+                providers.setdefault("openai_llm", {})["enabled"] = True
+                if not provider_exists("openai_llm"):
+                    providers["openai_llm"].update({
+                        "api_key": "${OPENAI_API_KEY}",
+                        "chat_base_url": "https://api.openai.com/v1",
+                        "chat_model": "gpt-4o-mini",
+                        "type": "openai",
+                        "capabilities": ["llm"],
+                    })
+
+                # Define the pipeline
+                yaml_config.setdefault("pipelines", {})[pipeline_name] = {
+                    "stt": "deepgram_stt",
+                    "llm": "openai_llm",
+                    "tts": "cambai_tts"
                 }
 
             # C6 Fix: Create default context

--- a/admin_ui/frontend/src/pages/Wizard.tsx
+++ b/admin_ui/frontend/src/pages/Wizard.tsx
@@ -22,6 +22,7 @@ interface SetupConfig {
     elevenlabs_key?: string;
     elevenlabs_agent_id?: string;
     cartesia_key?: string;
+    camb_key?: string;
     greeting: string;
     ai_name: string;
     ai_role: string;
@@ -870,6 +871,20 @@ exten => s,1,NoOp(AI Agent Call)
                     return;
                 }
             }
+            if (config.provider === 'cambai') {
+                if (!config.camb_key) {
+                    showToast('CAMB AI API key is required.', 'error');
+                    return;
+                }
+                if (!config.deepgram_key) {
+                    showToast('Deepgram API key is required for CAMB AI pipeline (STT).', 'error');
+                    return;
+                }
+                if (!config.openai_key) {
+                    showToast('OpenAI API key is required for CAMB AI pipeline (LLM).', 'error');
+                    return;
+                }
+            }
         }
 
         if (step === 3) {
@@ -973,6 +988,36 @@ exten => s,1,NoOp(AI Agent Call)
                     } else {
                         throw new Error('ElevenLabs API Key is required');
                     }
+                }
+
+                if (config.provider === 'cambai') {
+                    // CAMB AI pipeline requires three keys: CAMB AI (TTS), Deepgram (STT), OpenAI (LLM)
+                    if (!config.camb_key) {
+                        throw new Error('CAMB AI API Key is required');
+                    }
+                    const cambRes = await axios.post('/api/wizard/validate-key', {
+                        provider: 'cambai',
+                        api_key: config.camb_key
+                    });
+                    if (!cambRes.data.valid) throw new Error(`CAMB AI Key Invalid: ${cambRes.data.error}`);
+
+                    if (!config.deepgram_key) {
+                        throw new Error('Deepgram API Key is required for CAMB AI pipeline (STT)');
+                    }
+                    const dgRes = await axios.post('/api/wizard/validate-key', {
+                        provider: 'deepgram',
+                        api_key: config.deepgram_key
+                    });
+                    if (!dgRes.data.valid) throw new Error(`Deepgram Key Invalid: ${dgRes.data.error}`);
+
+                    if (!config.openai_key) {
+                        throw new Error('OpenAI API Key is required for CAMB AI pipeline (LLM)');
+                    }
+                    const oaRes = await axios.post('/api/wizard/validate-key', {
+                        provider: 'openai',
+                        api_key: config.openai_key
+                    });
+                    if (!oaRes.data.valid) throw new Error(`OpenAI Key Invalid: ${oaRes.data.error}`);
                 }
 
                 // Only verify Local AI health for local_hybrid on step 3
@@ -1172,6 +1217,12 @@ exten => s,1,NoOp(AI Agent Call)
                                 id="elevenlabs_agent"
                                 title="ElevenLabs Conversational"
                                 description="High-quality voices with pre-configured agent. Configure voice, prompt, and tools in ElevenLabs dashboard."
+                                icon={Cloud}
+                            />
+                            <ProviderCard
+                                id="cambai"
+                                title="CAMB AI"
+                                description="Multilingual MARS TTS (mars-flash ~150ms latency, voice cloning, 16+ languages). Pipeline: Deepgram STT + OpenAI LLM + CAMB AI TTS."
                                 icon={Cloud}
                             />
                         </div>
@@ -1794,6 +1845,86 @@ exten => s,1,NoOp(AI Agent Call)
                                         <li>Enable "Require authentication" in security settings</li>
                                         <li>Add client tools (hangup_call, blind_transfer, etc.)</li>
                                     </ul>
+                                </div>
+                            </div>
+                        )}
+
+                        {config.provider === 'cambai' && (
+                            <div className="space-y-4">
+                                <div className="bg-blue-50/50 dark:bg-blue-900/10 p-4 rounded-md border border-blue-100 dark:border-blue-900/20 text-sm text-blue-800 dark:text-blue-300">
+                                    <p className="font-semibold mb-1">CAMB AI Pipeline</p>
+                                    <p className="text-blue-700 dark:text-blue-400">
+                                        Pipeline mode using <strong>Deepgram STT</strong> + <strong>OpenAI LLM</strong> + <strong>CAMB AI TTS</strong> (mars-flash, ~150ms latency).
+                                        Requires three API keys.
+                                    </p>
+                                </div>
+                                <div className="space-y-2">
+                                    <label className="text-sm font-medium">CAMB AI API Key</label>
+                                    <div className="flex space-x-2">
+                                        <input
+                                            type="password"
+                                            className="w-full p-2 rounded-md border border-input bg-background"
+                                            value={config.camb_key}
+                                            onChange={e => setConfig({ ...config, camb_key: e.target.value })}
+                                            placeholder="UUID..."
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => handleTestKey('cambai', config.camb_key || '')}
+                                            className="px-3 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                                            disabled={loading}
+                                        >
+                                            Test
+                                        </button>
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                        Get yours at{' '}
+                                        <a href="https://studio.camb.ai" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                                            studio.camb.ai
+                                        </a>
+                                    </p>
+                                </div>
+                                <div className="space-y-2">
+                                    <label className="text-sm font-medium">Deepgram API Key (for STT)</label>
+                                    <div className="flex space-x-2">
+                                        <input
+                                            type="password"
+                                            className="w-full p-2 rounded-md border border-input bg-background"
+                                            value={config.deepgram_key}
+                                            onChange={e => setConfig({ ...config, deepgram_key: e.target.value })}
+                                            placeholder="Token..."
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => handleTestKey('deepgram', config.deepgram_key || '')}
+                                            className="px-3 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                                            disabled={loading}
+                                        >
+                                            Test
+                                        </button>
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">For speech-to-text transcription.</p>
+                                </div>
+                                <div className="space-y-2">
+                                    <label className="text-sm font-medium">OpenAI API Key (for LLM)</label>
+                                    <div className="flex space-x-2">
+                                        <input
+                                            type="password"
+                                            className="w-full p-2 rounded-md border border-input bg-background"
+                                            value={config.openai_key}
+                                            onChange={e => setConfig({ ...config, openai_key: e.target.value })}
+                                            placeholder="sk-..."
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => handleTestKey('openai', config.openai_key || '')}
+                                            className="px-3 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                                            disabled={loading}
+                                        >
+                                            Test
+                                        </button>
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">For LLM reasoning (gpt-4o-mini by default).</p>
                                 </div>
                             </div>
                         )}

--- a/config/ai-agent.golden-cambai.yaml
+++ b/config/ai-agent.golden-cambai.yaml
@@ -1,0 +1,122 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# Golden Baseline: CAMB AI TTS - Pipeline Mode with MARS Models
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# CAMB AI provides high-quality, low-latency text-to-speech with the MARS
+# model family. This config uses CAMB AI for TTS in a modular pipeline
+# with Deepgram STT and OpenAI LLM.
+#
+# Requirements:
+#   - CAMB_API_KEY in .env file (get from https://studio.camb.ai)
+#   - DEEPGRAM_API_KEY in .env file (for STT)
+#   - OPENAI_API_KEY in .env file (for LLM)
+#   - Asterisk 18+ with ARI enabled
+#
+# Performance:
+#   - mars-flash: ~150ms latency (real-time conversations)
+#   - mars-pro: 800ms-2s (higher quality, translation, audiobooks)
+#   - mars-instruct: Director-level control for TV/film
+#
+# Best for:
+#   - Multilingual voice agents (16+ languages)
+#   - Voice cloning with custom voices
+#   - Low-latency real-time conversations (mars-flash)
+#
+# For detailed parameter explanations, see: docs/Configuration-Reference.md
+# ═══════════════════════════════════════════════════════════════════════════
+
+config_version: 6
+active_pipeline: cambai_pipeline
+default_provider: local  # Pipeline mode - provider not used directly
+
+# Audio Transport
+audio_transport: audiosocket
+audiosocket:
+  format: ulaw
+  host: 0.0.0.0
+  port: 8090
+
+# Playback Mode
+downstream_mode: stream
+
+# ─── Pipelines ───────────────────────────────────────────────────────────
+pipelines:
+  cambai_pipeline:
+    stt: deepgram_stt
+    llm: openai_llm
+    tts: cambai_tts
+
+  # Alternative: Use with local STT for fully self-hosted STT + cloud TTS
+  cambai_local_stt:
+    stt: local_stt
+    llm: openai_llm
+    tts: cambai_tts
+
+# ─── Contexts ────────────────────────────────────────────────────────────
+contexts:
+  default:
+    greeting: Hello, how can I help you today?
+    profile: telephony_ulaw_8k
+    prompt: You are a helpful AI assistant. Be concise and clear.
+    pipeline: cambai_pipeline
+  demo_cambai:
+    greeting: "Hi! I'm Ava powered by CAMB AI voice synthesis. Ask me anything!"
+    prompt: "You are Ava (Asterisk Voice Agent) demonstrating CAMB AI TTS. Be helpful and conversational."
+    profile: telephony_ulaw_8k
+    pipeline: cambai_pipeline
+
+# ─── Providers ───────────────────────────────────────────────────────────
+providers:
+  cambai:
+    enabled: true
+    # api_key loaded from CAMB_API_KEY env var
+    voice_id: 147320
+    speech_model: mars-flash   # mars-flash | mars-pro | mars-instruct
+    language: en-us            # BCP-47: en-us, es-es, fr-fr, de-de, ja-jp, etc.
+    output_format: pcm_s16le
+
+  # Fallback local provider for non-pipeline calls
+  local:
+    enabled: true
+    ws_url: ${LOCAL_WS_URL:-ws://127.0.0.1:8765}
+
+# ─── LLM ─────────────────────────────────────────────────────────────────
+llm:
+  provider: openai
+  model: gpt-4o-mini
+  prompt: You are a helpful AI phone assistant. Keep responses concise.
+  initial_greeting: Hello, how can I help you today?
+  max_tokens: 300
+
+# ─── Barge-In ────────────────────────────────────────────────────────────
+barge_in:
+  enabled: true
+  energy_threshold: 700
+  initial_protection_ms: 100
+  min_ms: 150
+  post_tts_end_protection_ms: 100
+
+# ─── VAD ─────────────────────────────────────────────────────────────────
+vad:
+  enhanced_enabled: true
+  fallback_buffer_size: 128000
+  fallback_enabled: true
+  fallback_interval_ms: 4000
+  max_utterance_duration_ms: 10000
+  min_utterance_duration_ms: 600
+  use_provider_vad: false
+  utterance_padding_ms: 200
+  webrtc_aggressiveness: 1
+  webrtc_end_silence_frames: 50
+  webrtc_start_frames: 3
+
+# ─── Streaming ───────────────────────────────────────────────────────────
+streaming:
+  encoding: ulaw
+  sample_rate: 8000
+
+# ─── Audio Profiles ──────────────────────────────────────────────────────
+profiles:
+  telephony_ulaw_8k:
+    encoding: ulaw
+    sample_rate: 8000

--- a/src/config.py
+++ b/src/config.py
@@ -365,7 +365,7 @@ class GroqTTSProviderConfig(BaseModel):
 
 class ElevenLabsProviderConfig(BaseModel):
     """ElevenLabs TTS provider configuration.
-    
+
     API Reference: https://elevenlabs.io/docs/api-reference/text-to-speech
     """
     enabled: bool = Field(default=True)
@@ -381,6 +381,26 @@ class ElevenLabsProviderConfig(BaseModel):
     similarity_boost: float = Field(default=0.75)
     style: float = Field(default=0.0)
     use_speaker_boost: bool = Field(default=True)
+    # Provider-specific farewell hangup delay (overrides global)
+    farewell_hangup_delay_sec: Optional[float] = None
+
+
+class CambAiProviderConfig(BaseModel):
+    """CAMB AI TTS provider configuration.
+
+    Supports MARS speech models: mars-flash (~150ms latency),
+    mars-pro (higher quality), mars-instruct (director-level control).
+
+    API Reference: https://docs.camb.ai
+    """
+    enabled: bool = Field(default=True)
+    api_key: Optional[str] = None
+    voice_id: int = Field(default=147320)  # Default CAMB AI voice
+    speech_model: str = Field(default="mars-flash")  # mars-flash, mars-pro, mars-instruct
+    language: str = Field(default="en-us")  # BCP-47 language code
+    base_url: str = Field(default="https://client.camb.ai/apis")
+    # Output format for streaming TTS
+    output_format: str = Field(default="pcm_s16le")  # pcm_s16le for raw PCM
     # Provider-specific farewell hangup delay (overrides global)
     farewell_hangup_delay_sec: Optional[float] = None
 

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -39,6 +39,7 @@ GoogleProviderConfig = _parent_config.GoogleProviderConfig
 GroqSTTProviderConfig = _parent_config.GroqSTTProviderConfig
 GroqTTSProviderConfig = _parent_config.GroqTTSProviderConfig
 ElevenLabsProviderConfig = _parent_config.ElevenLabsProviderConfig
+CambAiProviderConfig = _parent_config.CambAiProviderConfig
 OpenAIRealtimeProviderConfig = _parent_config.OpenAIRealtimeProviderConfig
 AzureSTTProviderConfig = _parent_config.AzureSTTProviderConfig
 AzureTTSProviderConfig = _parent_config.AzureTTSProviderConfig
@@ -71,6 +72,7 @@ __all__ = [
     'GroqSTTProviderConfig',
     'GroqTTSProviderConfig',
     'ElevenLabsProviderConfig',
+    'CambAiProviderConfig',
     'OpenAIRealtimeProviderConfig',
     'AzureSTTProviderConfig',
     'AzureTTSProviderConfig',

--- a/src/pipelines/cambai.py
+++ b/src/pipelines/cambai.py
@@ -9,14 +9,15 @@ API Reference: https://docs.camb.ai
 """
 from __future__ import annotations
 
-import audioop
-from ..audio.resampler import resample_audio
+import io
 import time
 import uuid
+import wave
 from typing import Any, AsyncIterator, Callable, Dict, Optional
 
 import aiohttp
 
+from ..audio import resample_audio, pcm16le_to_mulaw
 from ..config import AppConfig, CambAiProviderConfig
 from ..logging_config import get_logger
 from .base import TTSComponent
@@ -179,12 +180,14 @@ class CambAiTTSAdapter(TTSComponent):
         if output_format == "pcm_s16le":
             # Raw PCM 16-bit signed little-endian at 24kHz -> resample to 8kHz -> μ-law
             resampled, _ = resample_audio(raw_audio, CAMB_AI_PCM_SAMPLE_RATE, 8000)
-            return audioop.lin2ulaw(resampled, 2)
+            return pcm16le_to_mulaw(resampled)
         elif output_format == "wav":
-            # WAV has a 44-byte header, skip it to get raw PCM
-            pcm_data = raw_audio[44:] if len(raw_audio) > 44 else raw_audio
-            resampled, _ = resample_audio(pcm_data, CAMB_AI_PCM_SAMPLE_RATE, 8000)
-            return audioop.lin2ulaw(resampled, 2)
+            # Parse WAV container to extract raw PCM frames and sample rate
+            with wave.open(io.BytesIO(raw_audio), "rb") as wf:
+                pcm_data = wf.readframes(wf.getnframes())
+                source_rate = wf.getframerate()
+            resampled, _ = resample_audio(pcm_data, source_rate, 8000)
+            return pcm16le_to_mulaw(resampled)
         else:
             logger.warning(
                 "Unknown CAMB AI output format, passing through raw audio",

--- a/src/pipelines/cambai.py
+++ b/src/pipelines/cambai.py
@@ -1,0 +1,236 @@
+"""
+CAMB AI TTS Pipeline Adapter.
+
+Implements the TTSComponent interface for CAMB AI's MARS text-to-speech models.
+Supports streaming synthesis with mars-flash (~150ms latency), mars-pro, and
+mars-instruct models.
+
+API Reference: https://docs.camb.ai
+"""
+from __future__ import annotations
+
+import audioop
+from ..audio.resampler import resample_audio
+import time
+import uuid
+from typing import Any, AsyncIterator, Callable, Dict, Optional
+
+import aiohttp
+
+from ..config import AppConfig, CambAiProviderConfig
+from ..logging_config import get_logger
+from .base import TTSComponent
+
+logger = get_logger(__name__)
+
+# CAMB AI streaming TTS returns PCM at 24kHz by default for pcm_s16le
+CAMB_AI_PCM_SAMPLE_RATE = 24000
+
+
+class CambAiTTSAdapter(TTSComponent):
+    """
+    CAMB AI TTS adapter for pipeline orchestrator.
+
+    Converts text to speech using CAMB AI's MARS models with automatic
+    audio format conversion to μ-law 8kHz for telephony.
+    """
+
+    def __init__(
+        self,
+        component_key: str,
+        app_config: AppConfig,
+        provider_config: CambAiProviderConfig,
+        options: Optional[Dict[str, Any]] = None,
+        *,
+        session_factory: Optional[Callable[[], aiohttp.ClientSession]] = None,
+    ):
+        self.component_key = component_key
+        self._app_config = app_config
+        self._provider_config = provider_config
+        self._pipeline_defaults = options or {}
+        self._session_factory = session_factory
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def start(self) -> None:
+        logger.debug(
+            "CAMB AI TTS adapter initialized",
+            component=self.component_key,
+            voice_id=self._provider_config.voice_id,
+            speech_model=self._provider_config.speech_model,
+            language=self._provider_config.language,
+        )
+
+    async def stop(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    async def open_call(self, call_id: str, options: Dict[str, Any]) -> None:
+        await self._ensure_session()
+
+    async def close_call(self, call_id: str) -> None:
+        pass
+
+    async def validate_connectivity(self, options: Dict[str, Any]) -> Dict[str, Any]:
+        merged = self._compose_options(options or {})
+        return await super().validate_connectivity(merged)
+
+    async def synthesize(
+        self,
+        call_id: str,
+        text: str,
+        options: Dict[str, Any],
+    ) -> AsyncIterator[bytes]:
+        """
+        Synthesize text to speech using CAMB AI streaming TTS API.
+
+        Yields audio chunks in μ-law 8kHz format for telephony playback.
+        """
+        if not text:
+            return
+            yield  # Makes this an async generator
+
+        await self._ensure_session()
+        merged = self._compose_options(options)
+
+        api_key = merged.get("api_key")
+        if not api_key:
+            raise RuntimeError("CAMB AI TTS requires an API key (CAMB_API_KEY)")
+
+        voice_id = merged.get("voice_id", self._provider_config.voice_id)
+        speech_model = merged.get("speech_model", self._provider_config.speech_model)
+        language = merged.get("language", self._provider_config.language)
+        output_format = merged.get("output_format", self._provider_config.output_format)
+
+        request_id = f"camb-tts-{uuid.uuid4().hex[:12]}"
+
+        base_url = merged.get("base_url", self._provider_config.base_url)
+        url = f"{base_url}/tts-stream"
+
+        payload = {
+            "text": text,
+            "voice_id": voice_id,
+            "language": language,
+            "speech_model": speech_model,
+            "output_configuration": {"format": output_format},
+        }
+
+        headers = {
+            "x-api-key": api_key,
+            "Content-Type": "application/json",
+        }
+
+        logger.info(
+            "CAMB AI TTS synthesis started",
+            call_id=call_id,
+            request_id=request_id,
+            text_preview=text[:64],
+            voice_id=voice_id,
+            speech_model=speech_model,
+            language=language,
+        )
+
+        started_at = time.perf_counter()
+
+        try:
+            async with self._session.post(url, json=payload, headers=headers) as response:
+                if response.status >= 400:
+                    body = await response.text()
+                    logger.error(
+                        "CAMB AI TTS synthesis failed",
+                        call_id=call_id,
+                        request_id=request_id,
+                        status=response.status,
+                        body=body,
+                    )
+                    response.raise_for_status()
+
+                raw_audio = await response.read()
+                latency_ms = (time.perf_counter() - started_at) * 1000.0
+
+                # Convert PCM16 to μ-law 8kHz for telephony
+                converted = self._convert_to_ulaw(raw_audio, output_format)
+
+                logger.info(
+                    "CAMB AI TTS synthesis completed",
+                    call_id=call_id,
+                    request_id=request_id,
+                    latency_ms=round(latency_ms, 2),
+                    raw_bytes=len(raw_audio),
+                    output_bytes=len(converted),
+                )
+
+                chunk_ms = int(merged.get("chunk_size_ms", 20))
+                for chunk in self._chunk_audio(converted, chunk_ms):
+                    if chunk:
+                        yield chunk
+
+        except aiohttp.ClientError as exc:
+            logger.error(
+                "CAMB AI TTS HTTP error",
+                call_id=call_id,
+                request_id=request_id,
+                error=str(exc),
+            )
+            raise
+
+    def _convert_to_ulaw(self, raw_audio: bytes, output_format: str) -> bytes:
+        """Convert CAMB AI audio output to μ-law 8kHz for telephony."""
+        if output_format == "pcm_s16le":
+            # Raw PCM 16-bit signed little-endian at 24kHz -> resample to 8kHz -> μ-law
+            resampled, _ = resample_audio(raw_audio, CAMB_AI_PCM_SAMPLE_RATE, 8000)
+            return audioop.lin2ulaw(resampled, 2)
+        elif output_format == "wav":
+            # WAV has a 44-byte header, skip it to get raw PCM
+            pcm_data = raw_audio[44:] if len(raw_audio) > 44 else raw_audio
+            resampled, _ = resample_audio(pcm_data, CAMB_AI_PCM_SAMPLE_RATE, 8000)
+            return audioop.lin2ulaw(resampled, 2)
+        else:
+            logger.warning(
+                "Unknown CAMB AI output format, passing through raw audio",
+                output_format=output_format,
+            )
+            return raw_audio
+
+    async def _ensure_session(self) -> None:
+        if self._session and not self._session.closed:
+            return
+        factory = self._session_factory or aiohttp.ClientSession
+        self._session = factory()
+
+    def _compose_options(self, runtime_options: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Merge runtime options with defaults."""
+        runtime_options = runtime_options or {}
+
+        merged = {
+            "api_key": runtime_options.get("api_key",
+                self._pipeline_defaults.get("api_key", self._provider_config.api_key)),
+            "voice_id": runtime_options.get("voice_id",
+                self._pipeline_defaults.get("voice_id", self._provider_config.voice_id)),
+            "speech_model": runtime_options.get("speech_model",
+                self._pipeline_defaults.get("speech_model", self._provider_config.speech_model)),
+            "language": runtime_options.get("language",
+                self._pipeline_defaults.get("language", self._provider_config.language)),
+            "base_url": runtime_options.get("base_url",
+                self._pipeline_defaults.get("base_url", self._provider_config.base_url)),
+            "output_format": runtime_options.get("output_format",
+                self._pipeline_defaults.get("output_format", self._provider_config.output_format)),
+            "chunk_size_ms": runtime_options.get("chunk_size_ms",
+                self._pipeline_defaults.get("chunk_size_ms", 20)),
+        }
+
+        return merged
+
+    def _chunk_audio(self, audio: bytes, chunk_ms: int = 20) -> list:
+        """Split μ-law audio into chunks for streaming playback."""
+        # μ-law at 8kHz: 8 bytes per ms
+        bytes_per_ms = 8
+        chunk_size = bytes_per_ms * chunk_ms
+
+        chunks = []
+        for i in range(0, len(audio), chunk_size):
+            chunk = audio[i:i + chunk_size]
+            if chunk:
+                chunks.append(chunk)
+
+        return chunks

--- a/src/pipelines/orchestrator.py
+++ b/src/pipelines/orchestrator.py
@@ -19,6 +19,7 @@ from ..config import (
     PipelineEntry,
     AzureSTTProviderConfig,
     AzureTTSProviderConfig,
+    CambAiProviderConfig,
     DeepgramProviderConfig,
     ElevenLabsProviderConfig,
     GoogleProviderConfig,
@@ -42,6 +43,7 @@ from .groq import GroqSTTAdapter, GroqTTSAdapter
 from .minimax import MiniMaxLLMAdapter
 from .telnyx import TelnyxLLMAdapter
 from .azure import AzureSTTFastAdapter, AzureSTTRealtimeAdapter, AzureTTSAdapter
+from .cambai import CambAiTTSAdapter
 
 logger = get_logger(__name__)
 
@@ -233,6 +235,7 @@ class PipelineOrchestrator:
         self._minimax_llm_provider_config: Optional[MiniMaxLLMProviderConfig] = self._hydrate_minimax_llm_config()
         self._google_provider_config: Optional[GoogleProviderConfig] = self._hydrate_google_config()
         self._elevenlabs_provider_config: Optional[ElevenLabsProviderConfig] = self._hydrate_elevenlabs_config()
+        self._cambai_provider_config: Optional[CambAiProviderConfig] = self._hydrate_cambai_config()
         self._groq_stt_provider_config: Optional[GroqSTTProviderConfig] = self._hydrate_groq_stt_config()
         self._groq_tts_provider_config: Optional[GroqTTSProviderConfig] = self._hydrate_groq_tts_config()
         self._azure_stt_provider_config: Optional[AzureSTTProviderConfig] = self._hydrate_azure_stt_config()
@@ -615,6 +618,19 @@ class PipelineOrchestrator:
         else:
             logger.debug("ElevenLabs pipeline adapters not registered - API key unavailable")
 
+        # CAMB AI TTS adapter
+        if self._cambai_provider_config:
+            tts_factory = self._make_cambai_tts_factory(self._cambai_provider_config)
+            self.register_factory("cambai_tts", tts_factory)
+            logger.info(
+                "CAMB AI TTS pipeline adapter registered",
+                tts_factory="cambai_tts",
+                voice_id=self._cambai_provider_config.voice_id,
+                speech_model=self._cambai_provider_config.speech_model,
+            )
+        else:
+            logger.debug("CAMB AI TTS pipeline adapter not registered - API key unavailable or config missing")
+
         # Ollama LLM adapter - for self-hosted local LLMs
         # Read config from providers.ollama_llm in YAML if available
         ollama_provider_config = {}
@@ -972,6 +988,23 @@ class PipelineOrchestrator:
 
         return factory
 
+    def _make_cambai_tts_factory(
+        self,
+        provider_config: CambAiProviderConfig,
+    ) -> ComponentFactory:
+        """Create factory for CAMB AI TTS adapter."""
+        config_payload = provider_config.model_dump()
+
+        def factory(component_key: str, options: Dict[str, Any]) -> Component:
+            return CambAiTTSAdapter(
+                component_key,
+                self.config,
+                CambAiProviderConfig(**config_payload),
+                options,
+            )
+
+        return factory
+
     def _hydrate_google_config(self) -> Optional[GoogleProviderConfig]:
         providers = getattr(self.config, "providers", {}) or {}
         raw_config = providers.get("google")
@@ -1078,6 +1111,51 @@ class PipelineOrchestrator:
         if not config.api_key:
             config = ElevenLabsProviderConfig(
                 **{**config.model_dump(), "api_key": os.getenv("ELEVENLABS_API_KEY")}
+            )
+
+        return config
+
+    def _hydrate_cambai_config(self) -> Optional[CambAiProviderConfig]:
+        """Hydrate CAMB AI provider config from YAML or env."""
+        providers = getattr(self.config, "providers", {}) or {}
+        raw_config = providers.get("cambai") or providers.get("cambai_tts")
+        if not raw_config:
+            # Check if API key exists in env
+            api_key = os.getenv("CAMB_API_KEY")
+            if api_key:
+                return CambAiProviderConfig(api_key=api_key)
+            return None
+        if isinstance(raw_config, CambAiProviderConfig):
+            config = raw_config
+        elif isinstance(raw_config, dict):
+            try:
+                camb_fields = set(CambAiProviderConfig.model_fields.keys())
+                filtered = {}
+                for k, v in raw_config.items():
+                    if k not in camb_fields:
+                        continue
+                    if isinstance(v, str) and v == "":
+                        continue
+                    filtered[k] = v
+                config = CambAiProviderConfig(**filtered)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to hydrate CAMB AI provider config for pipelines",
+                    error=str(exc),
+                )
+                return None
+        else:
+            return None
+
+        if not config.api_key and not os.getenv("CAMB_API_KEY"):
+            logger.warning(
+                "CAMB AI pipeline adapter requires CAMB_API_KEY; falling back to placeholder adapter",
+            )
+            return None
+
+        if not config.api_key:
+            config = CambAiProviderConfig(
+                **{**config.model_dump(), "api_key": os.getenv("CAMB_API_KEY")}
             )
 
         return config

--- a/tests/test_pipeline_cambai_adapters.py
+++ b/tests/test_pipeline_cambai_adapters.py
@@ -60,6 +60,10 @@ class _FakeResponse:
     async def text(self):
         return self._body.decode("utf-8", errors="ignore")
 
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise Exception(f"HTTP {self.status}")
+
 
 class _FakeSession:
     def __init__(self, body: bytes, status: int = 200):

--- a/tests/test_pipeline_cambai_adapters.py
+++ b/tests/test_pipeline_cambai_adapters.py
@@ -1,0 +1,288 @@
+import asyncio
+import json
+import os
+import struct
+
+import pytest
+
+from src.config import AppConfig, CambAiProviderConfig
+from src.pipelines.cambai import CambAiTTSAdapter
+from src.pipelines.orchestrator import PipelineOrchestrator
+
+
+def _build_app_config(api_key: str = "test-key") -> AppConfig:
+    providers = {
+        "cambai": {
+            "api_key": api_key,
+            "voice_id": 147320,
+            "speech_model": "mars-flash",
+            "language": "en-us",
+            "base_url": "https://client.camb.ai/apis",
+            "output_format": "pcm_s16le",
+        },
+        "local": {
+            "ws_url": "ws://127.0.0.1:8765",
+        },
+    }
+    pipelines = {
+        "cambai_pipeline": {
+            "stt": "local_stt",
+            "llm": "local_llm",
+            "tts": "cambai_tts",
+        }
+    }
+    return AppConfig(
+        default_provider="local",
+        providers=providers,
+        asterisk={"host": "127.0.0.1", "username": "ari", "password": "secret"},
+        llm={"initial_greeting": "hi", "prompt": "prompt", "model": "gpt-4o"},
+        audio_transport="audiosocket",
+        downstream_mode="stream",
+        pipelines=pipelines,
+        active_pipeline="cambai_pipeline",
+    )
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def read(self):
+        return self._body
+
+    async def text(self):
+        return self._body.decode("utf-8", errors="ignore")
+
+
+class _FakeSession:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self._status = status
+        self.requests = []
+        self.closed = False
+
+    def post(self, url, json=None, params=None, headers=None, data=None, timeout=None):
+        self.requests.append(
+            {"url": url, "json": json, "params": params, "headers": headers}
+        )
+        return _FakeResponse(self._body, status=self._status)
+
+    async def close(self):
+        self.closed = True
+
+
+def _make_pcm16_silence(num_samples: int = 320) -> bytes:
+    """Generate silent PCM16 audio (320 samples = 20ms at 16kHz)."""
+    return b"\x00\x00" * num_samples
+
+
+# ─── Unit Tests (mocked HTTP) ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cambai_tts_adapter_sends_correct_payload():
+    """Verify the adapter sends the correct payload to CAMB AI API."""
+    app_config = _build_app_config()
+    provider_config = CambAiProviderConfig(**app_config.providers["cambai"])
+
+    # Fake PCM16 audio response (simulate 24kHz, will be resampled to 8kHz)
+    pcm_audio = _make_pcm16_silence(480)  # 20ms at 24kHz
+    fake_session = _FakeSession(pcm_audio)
+
+    adapter = CambAiTTSAdapter(
+        "cambai_tts",
+        app_config,
+        provider_config,
+        {},
+        session_factory=lambda: fake_session,
+    )
+
+    await adapter.start()
+    await adapter.open_call("call-1", {})
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "Hello from CAMB AI", {})]
+
+    # Verify request was made
+    assert len(fake_session.requests) == 1
+    request = fake_session.requests[0]
+
+    # Verify URL
+    assert request["url"] == "https://client.camb.ai/apis/tts-stream"
+
+    # Verify payload
+    payload = request["json"]
+    assert payload["text"] == "Hello from CAMB AI"
+    assert payload["voice_id"] == 147320
+    assert payload["language"] == "en-us"
+    assert payload["speech_model"] == "mars-flash"
+    assert payload["output_configuration"] == {"format": "pcm_s16le"}
+
+    # Verify auth header
+    assert request["headers"]["x-api-key"] == "test-key"
+    assert request["headers"]["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_cambai_tts_adapter_converts_pcm_to_ulaw():
+    """Verify PCM16 audio is converted to μ-law for telephony."""
+    app_config = _build_app_config()
+    provider_config = CambAiProviderConfig(**app_config.providers["cambai"])
+
+    # Create non-silent PCM16 audio so conversion produces non-empty output
+    # 960 samples at 24kHz = 40ms, resampled to 8kHz = 320 samples = 640 bytes μ-law
+    pcm_audio = struct.pack("<" + "h" * 960, *([1000] * 960))
+    fake_session = _FakeSession(pcm_audio)
+
+    adapter = CambAiTTSAdapter(
+        "cambai_tts",
+        app_config,
+        provider_config,
+        {},
+        session_factory=lambda: fake_session,
+    )
+
+    await adapter.start()
+    await adapter.open_call("call-1", {})
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "Test audio", {})]
+    synthesized = b"".join(chunks)
+
+    # Output should be non-empty μ-law audio
+    assert len(synthesized) > 0
+    # μ-law bytes should differ from the PCM input
+    assert synthesized != pcm_audio
+
+
+@pytest.mark.asyncio
+async def test_cambai_tts_adapter_empty_text_yields_nothing():
+    """Empty text should yield no audio chunks."""
+    app_config = _build_app_config()
+    provider_config = CambAiProviderConfig(**app_config.providers["cambai"])
+
+    fake_session = _FakeSession(b"")
+    adapter = CambAiTTSAdapter(
+        "cambai_tts",
+        app_config,
+        provider_config,
+        {},
+        session_factory=lambda: fake_session,
+    )
+
+    await adapter.start()
+    await adapter.open_call("call-1", {})
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "", {})]
+    assert chunks == []
+    # No HTTP request should have been made
+    assert len(fake_session.requests) == 0
+
+
+@pytest.mark.asyncio
+async def test_cambai_tts_adapter_api_error_raises():
+    """API errors should propagate as exceptions."""
+    app_config = _build_app_config()
+    provider_config = CambAiProviderConfig(**app_config.providers["cambai"])
+
+    fake_session = _FakeSession(b'{"error": "unauthorized"}', status=401)
+    adapter = CambAiTTSAdapter(
+        "cambai_tts",
+        app_config,
+        provider_config,
+        {},
+        session_factory=lambda: fake_session,
+    )
+
+    await adapter.start()
+    await adapter.open_call("call-1", {})
+
+    with pytest.raises(Exception):
+        chunks = [chunk async for chunk in adapter.synthesize("call-1", "Error test", {})]
+
+
+@pytest.mark.asyncio
+async def test_cambai_tts_adapter_runtime_option_overrides():
+    """Runtime options should override provider config defaults."""
+    app_config = _build_app_config()
+    provider_config = CambAiProviderConfig(**app_config.providers["cambai"])
+
+    pcm_audio = _make_pcm16_silence(480)
+    fake_session = _FakeSession(pcm_audio)
+
+    adapter = CambAiTTSAdapter(
+        "cambai_tts",
+        app_config,
+        provider_config,
+        {},
+        session_factory=lambda: fake_session,
+    )
+
+    await adapter.start()
+    await adapter.open_call("call-1", {})
+
+    # Override voice_id and language at runtime
+    runtime_opts = {"voice_id": 999999, "language": "es-es", "speech_model": "mars-pro"}
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "Hola", runtime_opts)]
+
+    payload = fake_session.requests[0]["json"]
+    assert payload["voice_id"] == 999999
+    assert payload["language"] == "es-es"
+    assert payload["speech_model"] == "mars-pro"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_orchestrator_registers_cambai_tts():
+    """Verify the orchestrator registers the cambai_tts factory."""
+    app_config = _build_app_config()
+    orchestrator = PipelineOrchestrator(app_config)
+    await orchestrator.start()
+
+    resolution = orchestrator.get_pipeline("call-1")
+    assert isinstance(resolution.tts_adapter, CambAiTTSAdapter)
+
+
+# ─── Integration Tests (live API) ───────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_cambai_tts_live_api():
+    """Integration test: call the real CAMB AI TTS API and verify audio output."""
+    api_key = os.getenv("CAMB_API_KEY")
+    if not api_key:
+        pytest.skip("CAMB_API_KEY not set — skipping live API test")
+
+    app_config = _build_app_config(api_key=api_key)
+    provider_config = CambAiProviderConfig(**app_config.providers["cambai"])
+
+    adapter = CambAiTTSAdapter(
+        "cambai_tts",
+        app_config,
+        provider_config,
+        {},
+    )
+
+    await adapter.start()
+    await adapter.open_call("call-live", {})
+
+    try:
+        chunks = []
+        async for chunk in adapter.synthesize("call-live", "Hello from CAMB AI test.", {}):
+            chunks.append(chunk)
+
+        synthesized = b"".join(chunks)
+
+        # Should produce non-empty μ-law audio
+        assert len(synthesized) > 100, f"Expected substantial audio, got {len(synthesized)} bytes"
+
+        # μ-law 8kHz at 20ms chunks = 160 bytes per chunk
+        for chunk in chunks:
+            assert len(chunk) <= 160, f"Chunk too large: {len(chunk)} bytes (expected ≤160 for 20ms μ-law)"
+    finally:
+        await adapter.stop()


### PR DESCRIPTION
## Summary

This PR adds CAMB AI as a TTS provider option in the Asterisk AI Voice Agent. CAMB AI is the localization engine of choice for brands like the Premier League, NBA, NASCAR, and the Australian Open, and we'd love to be available as a TTS option in this project for users who want high quality multilingual voice synthesis on their phone agents.

The integration follows the existing pipeline adapter pattern (similar to how ElevenLabs and Deepgram TTS slot in), so it should be easy to review.

## What's added

**Pipeline adapter:**
* `src/pipelines/cambai.py`: new `CambAiTTSAdapter` implementing the existing `TTSComponent` interface. Calls the CAMB AI streaming TTS endpoint, handles PCM16 to ulaw 8kHz conversion for telephony, and yields audio in 20ms chunks.

**Config:**
* `src/config.py`: new `CambAiProviderConfig` pydantic model with voice_id, speech_model (mars-flash, mars-pro, mars-instruct), language, and output format.
* `src/config/__init__.py`: re-export of the new config class.
* `src/pipelines/orchestrator.py`: hydration via `_hydrate_cambai_config` and factory registration as `cambai_tts` so existing pipelines can reference it.
* `config/ai-agent.golden-cambai.yaml`: golden config example showing CAMB AI used in a pipeline with Deepgram STT and OpenAI LLM.
* `.env.example`: added `CAMB_API_KEY=` placeholder.

**Setup Wizard:**
* `admin_ui/frontend/src/pages/Wizard.tsx`: new provider card, three-field API key step (CAMB AI, Deepgram, OpenAI), and validation logic.
* `admin_ui/backend/api/wizard.py`: `SetupConfig.camb_key` field, `validate-key` handler that performs a small TTS call to verify the key, and a save handler that writes the cambai_pipeline configuration to ai-agent.yaml.

**Tests:**
* `tests/test_pipeline_cambai_adapters.py`: 6 unit tests using the existing fake-session pattern from the Deepgram tests, plus 1 live API integration test guarded by `CAMB_API_KEY`. All 7 pass locally.

## How it fits in

CAMB AI is TTS-only, so it runs in pipeline mode (Deepgram STT + OpenAI LLM + CAMB AI TTS) using the existing PipelineOrchestrator. No changes to the orchestrator core, no new abstractions, just one more entry next to the existing `_hydrate_elevenlabs_config` and `_make_elevenlabs_tts_factory` patterns.

## Testing

```
python -m pytest tests/test_pipeline_cambai_adapters.py -v
```

Unit tests run with mocked HTTP. The integration test (`test_cambai_tts_live_api`) hits the real CAMB AI API when `CAMB_API_KEY` is set in the environment, otherwise it skips.

## About CAMB AI

CAMB AI provides MARS speech models with sub-150ms latency on mars-flash, voice cloning from short reference samples, and 16+ language support. More info at https://camb.ai and https://studio.camb.ai.

Happy to iterate on anything: naming, code style, where the files live, test coverage, the wizard UX. Thanks for considering this addition!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CAMB AI as a new text-to-speech provider and integrated it into pipelines with STT and LLM providers
  * Setup wizard updated to configure and validate CAMB AI credentials

* **Chores**
  * Added CAMB_API_KEY to example environment variables

* **Documentation**
  * Added example configuration demonstrating CAMB AI pipeline and recommended settings

* **Tests**
  * Added unit and integration tests covering CAMB AI TTS integration and orchestration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->