### PR TITLE
feat: add transcript search to Call History page

### DIFF
--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -257,7 +257,7 @@ async def list_calls(
     has_tool_calls: Optional[bool] = Query(None, description="Filter calls with tool executions"),
     min_duration: Optional[float] = Query(None, description="Minimum duration in seconds"),
     max_duration: Optional[float] = Query(None, description="Maximum duration in seconds"),
-    transcript_search: Optional[str] = Query(None, description="Search within conversation transcripts (case-insensitive substring match)"),
+    transcript_search: Optional[str] = Query(None, min_length=1, max_length=256, description="Search within conversation transcripts (case-insensitive substring match)"),
     order_by: str = Query("start_time", description="Column to order by"),
     order_dir: str = Query("DESC", description="Order direction (ASC/DESC)"),
 ):

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -242,66 +242,6 @@ def _record_to_summary_response(record) -> CallRecordSummaryResponse:
     )
 
 
-@router.get("/providers/health")
-async def get_providers_health():
-    """
-    Aggregate call outcomes per provider from the last 24 hours.
-
-    Returns a map of provider name -> health status.
-    Status values: healthy, degraded, error, no_data.
-    """
-    store = _get_call_history_store()
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
-
-    provider_stats: dict[str, dict] = {}
-    page_size = 1000
-    offset = 0
-    while True:
-        records = await store.list(
-            limit=page_size,
-            offset=offset,
-            start_date=cutoff,
-            include_details=False,
-        )
-        if not records:
-            break
-        for r in records:
-            name = r.provider_name or "unknown"
-            if name not in provider_stats:
-                provider_stats[name] = {"total": 0, "succeeded": 0, "failed": 0}
-            provider_stats[name]["total"] += 1
-            if r.outcome in ("error", "failed"):
-                provider_stats[name]["failed"] += 1
-            else:
-                provider_stats[name]["succeeded"] += 1
-        if len(records) < page_size:
-            break
-        offset += page_size
-
-    result: dict[str, dict] = {}
-    for name, stats in provider_stats.items():
-        total = stats["total"]
-        succeeded = stats["succeeded"]
-        failed = stats["failed"]
-        if total == 0:
-            status = "no_data"
-        elif failed == 0:
-            status = "healthy"
-        elif failed / total < 0.3:
-            status = "degraded"
-        else:
-            status = "error"
-        result[name] = {
-            "status": status,
-            "total": total,
-            "succeeded": succeeded,
-            "failed": failed,
-            "summary": f"{succeeded}/{total} calls succeeded in last 24h",
-        }
-
-    return result
-
-
 @router.get("/calls", response_model=CallListResponse)
 async def list_calls(
     page: int = Query(1, ge=1, description="Page number"),

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -242,6 +242,58 @@ def _record_to_summary_response(record) -> CallRecordSummaryResponse:
     )
 
 
+@router.get("/providers/health")
+async def get_providers_health():
+    """
+    Aggregate call outcomes per provider from the last 24 hours.
+
+    Returns a map of provider name -> health status.
+    Status values: healthy, degraded, error, no_data.
+    """
+    store = _get_call_history_store()
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    records = await store.list(
+        limit=10000,
+        offset=0,
+        start_date=cutoff,
+        include_details=False,
+    )
+
+    provider_stats: dict[str, dict] = {}
+    for r in records:
+        name = r.provider_name or "unknown"
+        if name not in provider_stats:
+            provider_stats[name] = {"total": 0, "succeeded": 0, "failed": 0}
+        provider_stats[name]["total"] += 1
+        if r.outcome in ("error", "failed"):
+            provider_stats[name]["failed"] += 1
+        else:
+            provider_stats[name]["succeeded"] += 1
+
+    result: dict[str, dict] = {}
+    for name, stats in provider_stats.items():
+        total = stats["total"]
+        succeeded = stats["succeeded"]
+        failed = stats["failed"]
+        if total == 0:
+            status = "no_data"
+        elif failed == 0:
+            status = "healthy"
+        elif failed / total < 0.3:
+            status = "degraded"
+        else:
+            status = "error"
+        result[name] = {
+            "status": status,
+            "total": total,
+            "succeeded": succeeded,
+            "failed": failed,
+            "summary": f"{succeeded}/{total} calls succeeded in last 24h",
+        }
+
+    return result
+
+
 @router.get("/calls", response_model=CallListResponse)
 async def list_calls(
     page: int = Query(1, ge=1, description="Page number"),

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -257,6 +257,7 @@ async def list_calls(
     has_tool_calls: Optional[bool] = Query(None, description="Filter calls with tool executions"),
     min_duration: Optional[float] = Query(None, description="Minimum duration in seconds"),
     max_duration: Optional[float] = Query(None, description="Maximum duration in seconds"),
+    transcript_search: Optional[str] = Query(None, description="Search within conversation transcripts (case-insensitive substring match)"),
     order_by: str = Query("start_time", description="Column to order by"),
     order_dir: str = Query("DESC", description="Order direction (ASC/DESC)"),
 ):
@@ -281,6 +282,7 @@ async def list_calls(
         has_tool_calls=has_tool_calls,
         min_duration=min_duration,
         max_duration=max_duration,
+        transcript_search=transcript_search,
     )
     
     # Get paginated records
@@ -299,6 +301,7 @@ async def list_calls(
         has_tool_calls=has_tool_calls,
         min_duration=min_duration,
         max_duration=max_duration,
+        transcript_search=transcript_search,
         order_by=order_by,
         order_dir=order_dir,
         include_details=False,

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -252,23 +252,31 @@ async def get_providers_health():
     """
     store = _get_call_history_store()
     cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
-    records = await store.list(
-        limit=10000,
-        offset=0,
-        start_date=cutoff,
-        include_details=False,
-    )
 
     provider_stats: dict[str, dict] = {}
-    for r in records:
-        name = r.provider_name or "unknown"
-        if name not in provider_stats:
-            provider_stats[name] = {"total": 0, "succeeded": 0, "failed": 0}
-        provider_stats[name]["total"] += 1
-        if r.outcome in ("error", "failed"):
-            provider_stats[name]["failed"] += 1
-        else:
-            provider_stats[name]["succeeded"] += 1
+    page_size = 1000
+    offset = 0
+    while True:
+        records = await store.list(
+            limit=page_size,
+            offset=offset,
+            start_date=cutoff,
+            include_details=False,
+        )
+        if not records:
+            break
+        for r in records:
+            name = r.provider_name or "unknown"
+            if name not in provider_stats:
+                provider_stats[name] = {"total": 0, "succeeded": 0, "failed": 0}
+            provider_stats[name]["total"] += 1
+            if r.outcome in ("error", "failed"):
+                provider_stats[name]["failed"] += 1
+            else:
+                provider_stats[name]["succeeded"] += 1
+        if len(records) < page_size:
+            break
+        offset += page_size
 
     result: dict[str, dict] = {}
     for name, stats in provider_stats.items():

--- a/admin_ui/frontend/src/pages/CallHistoryPage.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.tsx
@@ -164,13 +164,36 @@ const CallHistoryPage = () => {
     const [transcriptSearchInput, setTranscriptSearchInput] = useState('');
     const [transcriptSearch, setTranscriptSearch] = useState('');
     const transcriptSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const clearTranscriptSearch = useCallback(() => {
+        if (transcriptSearchTimer.current) {
+            clearTimeout(transcriptSearchTimer.current);
+            transcriptSearchTimer.current = null;
+        }
+        setTranscriptSearchInput('');
+        setTranscriptSearch('');
+        setPage(1);
+    }, []);
+
     const handleTranscriptSearchChange = useCallback((value: string) => {
         setTranscriptSearchInput(value);
         if (transcriptSearchTimer.current) clearTimeout(transcriptSearchTimer.current);
+        if (value === '') {
+            transcriptSearchTimer.current = null;
+            setTranscriptSearch('');
+            setPage(1);
+            return;
+        }
         transcriptSearchTimer.current = setTimeout(() => {
             setTranscriptSearch(value);
             setPage(1);
         }, 300);
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            if (transcriptSearchTimer.current) clearTimeout(transcriptSearchTimer.current);
+        };
     }, []);
 
     const fetchCalls = useCallback(async () => {
@@ -439,7 +462,7 @@ const CallHistoryPage = () => {
             start_date: '',
             end_date: '',
         });
-        setPage(1);
+        clearTranscriptSearch();
     };
 
     const hasActiveFilters = Object.values(filters).some(v => v !== '') || transcriptSearch !== '';
@@ -462,7 +485,7 @@ const CallHistoryPage = () => {
                         />
                         {transcriptSearchInput && (
                             <button
-                                onClick={() => { setTranscriptSearchInput(''); setTranscriptSearch(''); setPage(1); }}
+                                onClick={clearTranscriptSearch}
                                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                             >
                                 <X className="w-4 h-4" />

--- a/admin_ui/frontend/src/pages/CallHistoryPage.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.tsx
@@ -452,6 +452,9 @@ const CallHistoryPage = () => {
     };
 
     const clearFilters = () => {
+        if (transcriptSearchTimer.current) clearTimeout(transcriptSearchTimer.current);
+        setTranscriptSearchInput('');
+        setTranscriptSearch('');
         setFilters({
             caller_number: '',
             caller_name: '',

--- a/admin_ui/frontend/src/pages/CallHistoryPage.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.tsx
@@ -248,9 +248,15 @@ const CallHistoryPage = () => {
 
     useEffect(() => {
         fetchCalls();
+    }, [fetchCalls]);
+
+    useEffect(() => {
         fetchStats();
+    }, [fetchStats]);
+
+    useEffect(() => {
         fetchFilterOptions();
-    }, [fetchCalls, fetchStats, fetchFilterOptions]);
+    }, [fetchFilterOptions]);
 
     const cleanupAudio = useCallback(() => {
         if (audioRef.current) {
@@ -487,6 +493,8 @@ const CallHistoryPage = () => {
                         {transcriptSearchInput && (
                             <button
                                 onClick={clearTranscriptSearch}
+                                aria-label="Clear transcript search"
+                                title="Clear transcript search"
                                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                             >
                                 <X className="w-4 h-4" />

--- a/admin_ui/frontend/src/pages/CallHistoryPage.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.tsx
@@ -452,9 +452,7 @@ const CallHistoryPage = () => {
     };
 
     const clearFilters = () => {
-        if (transcriptSearchTimer.current) clearTimeout(transcriptSearchTimer.current);
-        setTranscriptSearchInput('');
-        setTranscriptSearch('');
+        clearTranscriptSearch();
         setFilters({
             caller_number: '',
             caller_name: '',
@@ -465,7 +463,6 @@ const CallHistoryPage = () => {
             start_date: '',
             end_date: '',
         });
-        clearTranscriptSearch();
     };
 
     const hasActiveFilters = Object.values(filters).some(v => v !== '') || transcriptSearch !== '';
@@ -484,6 +481,7 @@ const CallHistoryPage = () => {
                             value={transcriptSearchInput}
                             onChange={(e) => handleTranscriptSearchChange(e.target.value)}
                             placeholder="Search transcripts..."
+                            aria-label="Search transcripts"
                             className="pl-9 pr-8 py-2 bg-background border rounded-lg text-sm w-56 focus:outline-none focus:ring-1 focus:ring-ring"
                         />
                         {transcriptSearchInput && (

--- a/admin_ui/frontend/src/pages/CallHistoryPage.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.tsx
@@ -4,7 +4,7 @@ import {
     ChevronLeft, ChevronRight, RefreshCw, X, MessageSquare,
     Wrench, AlertCircle, CheckCircle, ArrowRightLeft, PhoneOff,
     BarChart3, Users, Timer, Activity, TrendingUp, Zap, PieChart,
-    Play, Pause, Volume2, FileAudio
+    Play, Pause, Volume2, FileAudio, Search
 } from 'lucide-react';
 import axios from 'axios';
 import { toast } from 'sonner';
@@ -160,6 +160,19 @@ const CallHistoryPage = () => {
     });
     const [showFilters, setShowFilters] = useState(false);
 
+    // Transcript search with debounce
+    const [transcriptSearchInput, setTranscriptSearchInput] = useState('');
+    const [transcriptSearch, setTranscriptSearch] = useState('');
+    const transcriptSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const handleTranscriptSearchChange = useCallback((value: string) => {
+        setTranscriptSearchInput(value);
+        if (transcriptSearchTimer.current) clearTimeout(transcriptSearchTimer.current);
+        transcriptSearchTimer.current = setTimeout(() => {
+            setTranscriptSearch(value);
+            setPage(1);
+        }, 300);
+    }, []);
+
     const fetchCalls = useCallback(async () => {
         try {
             setLoading(true);
@@ -174,7 +187,8 @@ const CallHistoryPage = () => {
             Object.entries(filters).forEach(([key, value]) => {
                 if (value) params[key] = value;
             });
-            
+            if (transcriptSearch) params.transcript_search = transcriptSearch;
+
             const res = await axios.get('/api/calls', { params });
             setCalls(res.data.calls);
             setTotal(res.data.total);
@@ -185,7 +199,7 @@ const CallHistoryPage = () => {
         } finally {
             setLoading(false);
         }
-    }, [page, pageSize, filters]);
+    }, [page, pageSize, filters, transcriptSearch]);
 
     const fetchStats = useCallback(async () => {
         try {
@@ -428,7 +442,7 @@ const CallHistoryPage = () => {
         setPage(1);
     };
 
-    const hasActiveFilters = Object.values(filters).some(v => v !== '');
+    const hasActiveFilters = Object.values(filters).some(v => v !== '') || transcriptSearch !== '';
     const modalCall = selectedCall ?? selectedCallSummary;
 
     return (
@@ -437,6 +451,24 @@ const CallHistoryPage = () => {
             <div className="flex items-center justify-between">
                 <h1 className="text-3xl font-bold">Call History</h1>
                 <div className="flex items-center gap-2">
+                    <div className="relative">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                        <input
+                            type="text"
+                            value={transcriptSearchInput}
+                            onChange={(e) => handleTranscriptSearchChange(e.target.value)}
+                            placeholder="Search transcripts..."
+                            className="pl-9 pr-8 py-2 bg-background border rounded-lg text-sm w-56 focus:outline-none focus:ring-1 focus:ring-ring"
+                        />
+                        {transcriptSearchInput && (
+                            <button
+                                onClick={() => { setTranscriptSearchInput(''); setTranscriptSearch(''); setPage(1); }}
+                                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                            >
+                                <X className="w-4 h-4" />
+                            </button>
+                        )}
+                    </div>
                     <button
                         onClick={() => setShowStats(!showStats)}
                         className={`p-2 rounded-lg border transition-colors ${showStats ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -43,12 +43,9 @@ const ProvidersPage: React.FC = () => {
     const { pendingRestart, setPendingChanges, clearPendingChanges } = usePendingChanges();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [localAIStatus, setLocalAIStatus] = useState<any>(null);
-    const [providerHealth, setProviderHealth] = useState<Record<string, { status: string; total: number; succeeded: number; failed: number; summary: string }>>({});
 
     useEffect(() => {
         fetchConfig();
-        fetchProviderHealth();
-        const healthInterval = setInterval(fetchProviderHealth, 30000);
         // Fetch local AI status for live model info on cards
         const fetchLocalStatus = async () => {
             try {
@@ -60,7 +57,7 @@ const ProvidersPage: React.FC = () => {
         };
         fetchLocalStatus();
         const interval = setInterval(fetchLocalStatus, 15000);
-        return () => { clearInterval(interval); clearInterval(healthInterval); };
+        return () => clearInterval(interval);
     }, []);
 
     const fetchConfig = async () => {
@@ -88,13 +85,6 @@ const ProvidersPage: React.FC = () => {
         } finally {
             setLoading(false);
         }
-    };
-
-    const fetchProviderHealth = async () => {
-        try {
-            const res = await axios.get('/api/providers/health');
-            setProviderHealth(res.data || {});
-        } catch { /* ignore */ }
     };
 
     const normalizeProviderCapabilities = (nextConfig: any) => {
@@ -756,12 +746,6 @@ const ProvidersPage: React.FC = () => {
                                         {!providerData.enabled && (
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
-                                        {(() => {
-                                            const health = providerHealth[name];
-                                            if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
-                                            const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
-                                            return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
-                                        })()}
                                     </div>
                                     <div className="flex flex-wrap gap-1.5 mt-1.5">
                                         {(() => {
@@ -921,12 +905,6 @@ const ProvidersPage: React.FC = () => {
                                         {!providerData.enabled && (
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
-                                        {(() => {
-                                            const health = providerHealth[name];
-                                            if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
-                                            const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
-                                            return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
-                                        })()}
                                     </div>
                                     <div className="flex flex-wrap gap-1.5 mt-1.5">
                                         {(providerData.capabilities || []).map((cap: string) => (

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -43,9 +43,12 @@ const ProvidersPage: React.FC = () => {
     const { pendingRestart, setPendingChanges, clearPendingChanges } = usePendingChanges();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [localAIStatus, setLocalAIStatus] = useState<any>(null);
+    const [providerHealth, setProviderHealth] = useState<Record<string, { status: string; total: number; succeeded: number; failed: number; summary: string }>>({});
 
     useEffect(() => {
         fetchConfig();
+        fetchProviderHealth();
+        const healthInterval = setInterval(fetchProviderHealth, 30000);
         // Fetch local AI status for live model info on cards
         const fetchLocalStatus = async () => {
             try {
@@ -57,7 +60,7 @@ const ProvidersPage: React.FC = () => {
         };
         fetchLocalStatus();
         const interval = setInterval(fetchLocalStatus, 15000);
-        return () => clearInterval(interval);
+        return () => { clearInterval(interval); clearInterval(healthInterval); };
     }, []);
 
     const fetchConfig = async () => {
@@ -85,6 +88,13 @@ const ProvidersPage: React.FC = () => {
         } finally {
             setLoading(false);
         }
+    };
+
+    const fetchProviderHealth = async () => {
+        try {
+            const res = await axios.get('/api/providers/health');
+            setProviderHealth(res.data || {});
+        } catch { /* ignore */ }
     };
 
     const normalizeProviderCapabilities = (nextConfig: any) => {
@@ -746,6 +756,12 @@ const ProvidersPage: React.FC = () => {
                                         {!providerData.enabled && (
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
+                                        {(() => {
+                                            const health = providerHealth[name];
+                                            if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
+                                            const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
+                                            return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
+                                        })()}
                                     </div>
                                     <div className="flex flex-wrap gap-1.5 mt-1.5">
                                         {(() => {
@@ -905,6 +921,12 @@ const ProvidersPage: React.FC = () => {
                                         {!providerData.enabled && (
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
+                                        {(() => {
+                                            const health = providerHealth[name];
+                                            if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
+                                            const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
+                                            return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
+                                        })()}
                                     </div>
                                     <div className="flex flex-wrap gap-1.5 mt-1.5">
                                         {(providerData.capabilities || []).map((cap: string) => (

--- a/src/core/call_history.py
+++ b/src/core/call_history.py
@@ -542,6 +542,7 @@ class CallHistoryStore:
                             .replace("_", "\\_")
                         )
                         conditions.append("LOWER(conversation_history) LIKE LOWER(?) ESCAPE '\\'")
+
                         params.append(f"%{escaped}%")
 
                     where_clause = " AND ".join(conditions) if conditions else "1=1"

--- a/src/core/call_history.py
+++ b/src/core/call_history.py
@@ -408,8 +408,14 @@ class CallHistoryStore:
                         conditions.append("duration_seconds <= ?")
                         params.append(max_duration)
                     if transcript_search:
-                        conditions.append("conversation_history LIKE ?")
-                        params.append(f"%{transcript_search}%")
+                        escaped = (
+                            transcript_search
+                            .replace("\\", "\\\\")
+                            .replace("%", "\\%")
+                            .replace("_", "\\_")
+                        )
+                        conditions.append("LOWER(conversation_history) LIKE LOWER(?) ESCAPE '\\'")
+                        params.append(f"%{escaped}%")
 
                     # Validate order_by to prevent SQL injection
                     valid_columns = [
@@ -529,8 +535,14 @@ class CallHistoryStore:
                         conditions.append("duration_seconds <= ?")
                         params.append(max_duration)
                     if transcript_search:
-                        conditions.append("conversation_history LIKE ?")
-                        params.append(f"%{transcript_search}%")
+                        escaped = (
+                            transcript_search
+                            .replace("\\", "\\\\")
+                            .replace("%", "\\%")
+                            .replace("_", "\\_")
+                        )
+                        conditions.append("LOWER(conversation_history) LIKE LOWER(?) ESCAPE '\\'")
+                        params.append(f"%{escaped}%")
 
                     where_clause = " AND ".join(conditions) if conditions else "1=1"
                     query = f"SELECT COUNT(*) FROM call_records WHERE {where_clause}"

--- a/src/core/call_history.py
+++ b/src/core/call_history.py
@@ -97,7 +97,17 @@ class CallRecord:
 
 class CallHistoryStore:
     """SQLite-based call history storage."""
-    
+
+    @staticmethod
+    def _escape_like(value: str) -> str:
+        """Escape special characters for use in a SQL LIKE pattern with ESCAPE '\\'."""
+        return (
+            value
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+
     _CREATE_TABLE_SQL = """
     CREATE TABLE IF NOT EXISTS call_records (
         id TEXT PRIMARY KEY,
@@ -408,12 +418,7 @@ class CallHistoryStore:
                         conditions.append("duration_seconds <= ?")
                         params.append(max_duration)
                     if transcript_search:
-                        escaped = (
-                            transcript_search
-                            .replace("\\", "\\\\")
-                            .replace("%", "\\%")
-                            .replace("_", "\\_")
-                        )
+                        escaped = self._escape_like(transcript_search)
                         conditions.append("LOWER(conversation_history) LIKE LOWER(?) ESCAPE '\\'")
                         params.append(f"%{escaped}%")
 
@@ -535,14 +540,8 @@ class CallHistoryStore:
                         conditions.append("duration_seconds <= ?")
                         params.append(max_duration)
                     if transcript_search:
-                        escaped = (
-                            transcript_search
-                            .replace("\\", "\\\\")
-                            .replace("%", "\\%")
-                            .replace("_", "\\_")
-                        )
+                        escaped = self._escape_like(transcript_search)
                         conditions.append("LOWER(conversation_history) LIKE LOWER(?) ESCAPE '\\'")
-
                         params.append(f"%{escaped}%")
 
                     where_clause = " AND ".join(conditions) if conditions else "1=1"

--- a/src/core/call_history.py
+++ b/src/core/call_history.py
@@ -332,6 +332,7 @@ class CallHistoryStore:
         has_tool_calls: Optional[bool] = None,
         min_duration: Optional[float] = None,
         max_duration: Optional[float] = None,
+        transcript_search: Optional[str] = None,
         order_by: str = "start_time",
         order_dir: str = "DESC",
         include_details: bool = True,
@@ -406,7 +407,10 @@ class CallHistoryStore:
                     if max_duration is not None:
                         conditions.append("duration_seconds <= ?")
                         params.append(max_duration)
-                    
+                    if transcript_search:
+                        conditions.append("conversation_history LIKE ?")
+                        params.append(f"%{transcript_search}%")
+
                     # Validate order_by to prevent SQL injection
                     valid_columns = [
                         'start_time', 'end_time', 'duration_seconds', 
@@ -476,6 +480,7 @@ class CallHistoryStore:
         has_tool_calls: Optional[bool] = None,
         min_duration: Optional[float] = None,
         max_duration: Optional[float] = None,
+        transcript_search: Optional[str] = None,
     ) -> int:
         """Count records matching filters."""
         if not self._enabled:
@@ -523,7 +528,10 @@ class CallHistoryStore:
                     if max_duration is not None:
                         conditions.append("duration_seconds <= ?")
                         params.append(max_duration)
-                    
+                    if transcript_search:
+                        conditions.append("conversation_history LIKE ?")
+                        params.append(f"%{transcript_search}%")
+
                     where_clause = " AND ".join(conditions) if conditions else "1=1"
                     query = f"SELECT COUNT(*) FROM call_records WHERE {where_clause}"
                     


### PR DESCRIPTION
## Summary

Adds a search input to the Call History page that filters calls by keyword match within conversation transcripts, as described in #308.

### Changes
- **Frontend**: Search input with `Search` icon in the header (next to existing filter/stats buttons), with 300ms debounced input and a clear button
- **Backend API**: New `transcript_search` query parameter on `GET /api/calls` endpoint
- **Store layer**: Case-insensitive `LIKE` filtering on the `conversation_history` column in SQLite

### Scope
~50 lines across 3 files (frontend component, backend API, store)

## Acceptance Criteria from #308
- [x] Search input visible on the Call History page (next to existing filters)
- [x] Filters displayed call entries by matching search query against transcript text
- [x] Case-insensitive substring match
- [x] Debounced input (300ms)
- [x] Clear button to reset search

Closes #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcript search: filter Call History by conversation content (case-insensitive substring match).
  * Search input with clear button and 300ms debounce for responsive typing.
  * Call counts and pagination now reflect active transcript filtering; "Clear all" treats transcript search as an active filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->