### PR TITLE
feat: add provider health indicator badges to Providers page

### DIFF
--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -252,23 +252,31 @@ async def get_providers_health():
     """
     store = _get_call_history_store()
     cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
-    records = await store.list(
-        limit=10000,
-        offset=0,
-        start_date=cutoff,
-        include_details=False,
-    )
 
     provider_stats: dict[str, dict] = {}
-    for r in records:
-        name = r.provider_name or "unknown"
-        if name not in provider_stats:
-            provider_stats[name] = {"total": 0, "succeeded": 0, "failed": 0}
-        provider_stats[name]["total"] += 1
-        if r.outcome in ("error", "failed"):
-            provider_stats[name]["failed"] += 1
-        else:
-            provider_stats[name]["succeeded"] += 1
+    page_size = 1000
+    offset = 0
+    while True:
+        records = await store.list(
+            limit=page_size,
+            offset=offset,
+            start_date=cutoff,
+            include_details=False,
+        )
+        if not records:
+            break
+        for r in records:
+            name = r.provider_name or "unknown"
+            if name not in provider_stats:
+                provider_stats[name] = {"total": 0, "succeeded": 0, "failed": 0}
+            provider_stats[name]["total"] += 1
+            if r.outcome in ("error", "failed", "abandoned"):
+                provider_stats[name]["failed"] += 1
+            else:
+                provider_stats[name]["succeeded"] += 1
+        if len(records) < page_size:
+            break
+        offset += page_size
 
     result: dict[str, dict] = {}
     for name, stats in provider_stats.items():

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -242,6 +242,58 @@ def _record_to_summary_response(record) -> CallRecordSummaryResponse:
     )
 
 
+@router.get("/providers/health")
+async def get_providers_health():
+    """
+    Aggregate call outcomes per provider from the last 24 hours.
+
+    Returns a map of provider name -> health status.
+    Status values: healthy, degraded, error, no_data.
+    """
+    store = _get_call_history_store()
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    records = await store.list(
+        limit=10000,
+        offset=0,
+        start_date=cutoff,
+        include_details=False,
+    )
+
+    provider_stats: dict[str, dict] = {}
+    for r in records:
+        name = r.provider_name or "unknown"
+        if name not in provider_stats:
+            provider_stats[name] = {"total": 0, "succeeded": 0, "failed": 0}
+        provider_stats[name]["total"] += 1
+        if r.outcome in ("error", "failed"):
+            provider_stats[name]["failed"] += 1
+        else:
+            provider_stats[name]["succeeded"] += 1
+
+    result: dict[str, dict] = {}
+    for name, stats in provider_stats.items():
+        total = stats["total"]
+        succeeded = stats["succeeded"]
+        failed = stats["failed"]
+        if total == 0:
+            status = "no_data"
+        elif failed == 0:
+            status = "healthy"
+        elif failed / total < 0.3:
+            status = "degraded"
+        else:
+            status = "error"
+        result[name] = {
+            "status": status,
+            "total": total,
+            "succeeded": succeeded,
+            "failed": failed,
+            "summary": f"{succeeded}/{total} calls succeeded in last 24h",
+        }
+
+    return result
+
+
 @router.get("/calls", response_model=CallListResponse)
 async def list_calls(
     page: int = Query(1, ge=1, description="Page number"),

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -12,7 +12,7 @@ import os
 import re
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pathlib import Path
 
@@ -163,6 +163,19 @@ class FilterOptionsResponse(BaseModel):
     outcomes: List[str] = []
 
 
+class ProviderHealthStatus(BaseModel):
+    """Health status for a single provider."""
+    status: str
+    total: int
+    failures: int
+    summary: str
+
+
+class ProviderHealthResponse(BaseModel):
+    """Response model for the /providers/health endpoint."""
+    providers: Dict[str, ProviderHealthStatus]
+
+
 def _get_call_history_store():
     """Get the call history store instance."""
     try:
@@ -242,7 +255,7 @@ def _record_to_summary_response(record) -> CallRecordSummaryResponse:
     )
 
 
-@router.get("/providers/health")
+@router.get("/providers/health", response_model=ProviderHealthResponse)
 async def get_providers_health():
     """
     Aggregate call outcomes per provider from the last 24 hours.
@@ -266,11 +279,13 @@ async def get_providers_health():
         if not records:
             break
         for r in records:
-            name = r.provider_name or "unknown"
+            # Normalize to lowercase so backend keys match frontend YAML config keys
+            name = (r.provider_name or "unknown").lower()
             if name not in provider_stats:
                 provider_stats[name] = {"total": 0, "succeeded": 0, "failed": 0}
             provider_stats[name]["total"] += 1
-            if r.outcome in ("error", "failed", "abandoned"):
+            # Valid CallRecord.outcome values: completed, transferred, error, abandoned
+            if r.outcome in ("error", "abandoned"):
                 provider_stats[name]["failed"] += 1
             else:
                 provider_stats[name]["succeeded"] += 1
@@ -278,7 +293,7 @@ async def get_providers_health():
             break
         offset += page_size
 
-    result: dict[str, dict] = {}
+    result: dict[str, ProviderHealthStatus] = {}
     for name, stats in provider_stats.items():
         total = stats["total"]
         succeeded = stats["succeeded"]
@@ -291,15 +306,14 @@ async def get_providers_health():
             status = "degraded"
         else:
             status = "error"
-        result[name] = {
-            "status": status,
-            "total": total,
-            "succeeded": succeeded,
-            "failed": failed,
-            "summary": f"{succeeded}/{total} calls succeeded in last 24h",
-        }
+        result[name] = ProviderHealthStatus(
+            status=status,
+            total=total,
+            failures=failed,
+            summary=f"{succeeded}/{total} calls succeeded in last 24h",
+        )
 
-    return result
+    return ProviderHealthResponse(providers=result)
 
 
 @router.get("/calls", response_model=CallListResponse)

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -44,6 +44,7 @@ const ProvidersPage: React.FC = () => {
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [localAIStatus, setLocalAIStatus] = useState<any>(null);
     const [providerHealth, setProviderHealth] = useState<Record<string, { status: string; total: number; succeeded: number; failed: number; summary: string }>>({});
+    const [providerHealthUnavailable, setProviderHealthUnavailable] = useState(false);
 
     useEffect(() => {
         fetchConfig();
@@ -94,7 +95,10 @@ const ProvidersPage: React.FC = () => {
         try {
             const res = await axios.get('/api/providers/health');
             setProviderHealth(res.data || {});
-        } catch { /* ignore */ }
+            setProviderHealthUnavailable(false);
+        } catch {
+            setProviderHealthUnavailable(true);
+        }
     };
 
     const normalizeProviderCapabilities = (nextConfig: any) => {
@@ -757,6 +761,7 @@ const ProvidersPage: React.FC = () => {
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
                                         {(() => {
+                                            if (providerHealthUnavailable) return <span className="w-2.5 h-2.5 bg-orange-400 rounded-full flex-shrink-0" title="Health data unavailable (API error)" />;
                                             const health = providerHealth[name];
                                             if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
                                             const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
@@ -922,6 +927,7 @@ const ProvidersPage: React.FC = () => {
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
                                         {(() => {
+                                            if (providerHealthUnavailable) return <span className="w-2.5 h-2.5 bg-orange-400 rounded-full flex-shrink-0" title="Health data unavailable (API error)" />;
                                             const health = providerHealth[name];
                                             if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
                                             const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -43,7 +43,7 @@ const ProvidersPage: React.FC = () => {
     const { pendingRestart, setPendingChanges, clearPendingChanges } = usePendingChanges();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [localAIStatus, setLocalAIStatus] = useState<any>(null);
-    const [providerHealth, setProviderHealth] = useState<Record<string, { status: string; total: number; succeeded: number; failed: number; summary: string }>>({});
+    const [providerHealth, setProviderHealth] = useState<Record<string, { status: string; total: number; failures: number; summary: string }>>({});
     const [providerHealthUnavailable, setProviderHealthUnavailable] = useState(false);
 
     useEffect(() => {
@@ -94,12 +94,26 @@ const ProvidersPage: React.FC = () => {
     const fetchProviderHealth = async () => {
         try {
             const res = await axios.get('/api/providers/health');
-            setProviderHealth(res.data || {});
+            setProviderHealth(res.data?.providers || {});
             setProviderHealthUnavailable(false);
         } catch {
             setProviderHealth({});
             setProviderHealthUnavailable(true);
         }
+    };
+
+    // Shared health dot indicator used by both Full Agent and Modular provider cards
+    const HealthDot: React.FC<{ name: string }> = ({ name }) => {
+        if (providerHealthUnavailable) {
+            return <span className="w-2.5 h-2.5 bg-orange-400 rounded-full flex-shrink-0" title="Health data unavailable (API error)" />;
+        }
+        // Normalize to lowercase to match backend key normalization
+        const health = providerHealth[name.toLowerCase()];
+        if (!health) {
+            return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
+        }
+        const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
+        return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
     };
 
     const normalizeProviderCapabilities = (nextConfig: any) => {
@@ -761,13 +775,7 @@ const ProvidersPage: React.FC = () => {
                                         {!providerData.enabled && (
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
-                                        {(() => {
-                                            if (providerHealthUnavailable) return <span className="w-2.5 h-2.5 bg-orange-400 rounded-full flex-shrink-0" title="Health data unavailable (API error)" />;
-                                            const health = providerHealth[name];
-                                            if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
-                                            const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
-                                            return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
-                                        })()}
+                                        <HealthDot name={name} />
                                     </div>
                                     <div className="flex flex-wrap gap-1.5 mt-1.5">
                                         {(() => {
@@ -927,13 +935,7 @@ const ProvidersPage: React.FC = () => {
                                         {!providerData.enabled && (
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
-                                        {(() => {
-                                            if (providerHealthUnavailable) return <span className="w-2.5 h-2.5 bg-orange-400 rounded-full flex-shrink-0" title="Health data unavailable (API error)" />;
-                                            const health = providerHealth[name];
-                                            if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
-                                            const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
-                                            return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
-                                        })()}
+                                        <HealthDot name={name} />
                                     </div>
                                     <div className="flex flex-wrap gap-1.5 mt-1.5">
                                         {(providerData.capabilities || []).map((cap: string) => (

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -43,9 +43,12 @@ const ProvidersPage: React.FC = () => {
     const { pendingRestart, setPendingChanges, clearPendingChanges } = usePendingChanges();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [localAIStatus, setLocalAIStatus] = useState<any>(null);
+    const [providerHealth, setProviderHealth] = useState<Record<string, { status: string; total: number; succeeded: number; failed: number; summary: string }>>({});
 
     useEffect(() => {
         fetchConfig();
+        fetchProviderHealth();
+        const healthInterval = setInterval(fetchProviderHealth, 30000);
         // Fetch local AI status for live model info on cards
         const fetchLocalStatus = async () => {
             try {
@@ -57,7 +60,7 @@ const ProvidersPage: React.FC = () => {
         };
         fetchLocalStatus();
         const interval = setInterval(fetchLocalStatus, 15000);
-        return () => clearInterval(interval);
+        return () => { clearInterval(interval); clearInterval(healthInterval); };
     }, []);
 
     const fetchConfig = async () => {
@@ -85,6 +88,13 @@ const ProvidersPage: React.FC = () => {
         } finally {
             setLoading(false);
         }
+    };
+
+    const fetchProviderHealth = async () => {
+        try {
+            const res = await axios.get('/api/providers/health');
+            setProviderHealth(res.data || {});
+        } catch { /* ignore */ }
     };
 
     const normalizeProviderCapabilities = (nextConfig: any) => {
@@ -746,6 +756,12 @@ const ProvidersPage: React.FC = () => {
                                         {!providerData.enabled && (
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
+                                        {(() => {
+                                            const health = providerHealth[name];
+                                            if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
+                                            const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
+                                            return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
+                                        })()}
                                     </div>
                                     <div className="flex flex-wrap gap-1.5 mt-1.5">
                                         {(() => {
@@ -905,6 +921,12 @@ const ProvidersPage: React.FC = () => {
                                         {!providerData.enabled && (
                                             <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded flex-shrink-0">Disabled</span>
                                         )}
+                                        {(() => {
+                                            const health = providerHealth[name];
+                                            if (!health) return <span className="w-2.5 h-2.5 bg-gray-400 rounded-full flex-shrink-0" title="No recent call data" />;
+                                            const colors: Record<string, string> = { healthy: 'bg-green-500', degraded: 'bg-yellow-500', error: 'bg-red-500', no_data: 'bg-gray-400' };
+                                            return <span className={`w-2.5 h-2.5 ${colors[health.status] || 'bg-gray-400'} rounded-full flex-shrink-0`} title={health.summary} />;
+                                        })()}
                                     </div>
                                     <div className="flex flex-wrap gap-1.5 mt-1.5">
                                         {(providerData.capabilities || []).map((cap: string) => (

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -97,6 +97,7 @@ const ProvidersPage: React.FC = () => {
             setProviderHealth(res.data || {});
             setProviderHealthUnavailable(false);
         } catch {
+            setProviderHealth({});
             setProviderHealthUnavailable(true);
         }
     };


### PR DESCRIPTION
## Summary

Adds colored health indicator dots on each provider card (both Full Agents and Modular Providers sections) that reflect call success/failure rates from the last 24 hours.

**Backend** (`GET /api/providers/health`):
- Aggregates call outcomes per provider from the call history store (last 24h)
- Returns status map: `healthy` (0% failures), `degraded` (<30%), `error` (>=30%), `no_data`
- Includes call count summary for tooltip display

**Frontend**:
- Green dot = all calls succeeded
- Yellow dot = some failures (<30%)
- Red dot = mostly failing (>=30%)
- Gray dot = no recent call data
- Hover tooltip shows stats (e.g. "23/25 calls succeeded in last 24h")
- Auto-refreshes every 30 seconds

Closes #307

## Acceptance Criteria
- [x] Each provider card shows a colored health indicator
- [x] Color reflects actual recent call success/failure rates
- [x] Hovering shows a brief summary of recent call stats
- [x] Providers with no recent calls show a neutral/gray indicator


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider health monitoring added: per-provider status (healthy, degraded, error, or no data) computed from the last 24 hours of call outcomes.
  * Visual status dots on provider cards with colors for unavailable, no-data, or mapped health states; tooltip shows a brief summary and counts.
  * Health data auto-refreshes every 30 seconds and gracefully indicates when data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->