### PR TITLE
feat: add live latency estimate display on Streaming settings page

### DIFF
--- a/admin_ui/frontend/src/pages/Advanced/StreamingPage.tsx
+++ b/admin_ui/frontend/src/pages/Advanced/StreamingPage.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import axios from 'axios';
 import { toast } from 'sonner';
 import yaml from 'js-yaml';
-import { Save, Zap, AlertCircle, RefreshCw, Loader2 } from 'lucide-react';
+import { Save, Zap, AlertCircle, RefreshCw, Loader2, Clock } from 'lucide-react';
 import { YamlErrorBanner, YamlErrorInfo } from '../../components/ui/YamlErrorBanner';
 import { ConfigSection } from '../../components/ui/ConfigSection';
 import { ConfigCard } from '../../components/ui/ConfigCard';
@@ -99,6 +99,55 @@ const StreamingPage = () => {
                 [field]: value
             }
         });
+    };
+
+    const latencyEstimate = useMemo(() => {
+        const sc = config.streaming || {};
+        // Base latency: STT recognition + LLM inference + TTS synthesis
+        let estimated = 3.0; // seconds baseline
+
+        // LLM→TTS streaming overlap significantly reduces time-to-first-audio
+        if (sc.pipeline_streaming_overlap ?? true) {
+            estimated -= 1.0;
+        }
+
+        // Filler audio makes perceived latency lower but adds actual processing
+        const fillerEnabled = sc.pipeline_filler_enabled ?? false;
+
+        // Jitter buffer adds proportional delay (baseline 950ms)
+        const jitterMs = sc.jitter_buffer_ms ?? 950;
+        estimated += (jitterMs - 950) / 1000;
+
+        // Min start threshold affects when playback begins (baseline 120ms)
+        const minStartMs = sc.min_start_ms ?? 120;
+        estimated += (minStartMs - 120) / 1000;
+
+        // Low watermark affects buffering delay (baseline 80ms)
+        const lowWatermarkMs = sc.low_watermark_ms ?? 80;
+        estimated += (lowWatermarkMs - 80) / 1000;
+
+        const actual = Math.max(0.5, estimated);
+        const perceived = fillerEnabled ? Math.max(0.3, actual - 0.7) : actual;
+
+        return { actual, perceived, fillerEnabled };
+    }, [config]);
+
+    const getLatencyColor = (seconds: number) => {
+        if (seconds < 2) return 'text-green-600 dark:text-green-400';
+        if (seconds < 3) return 'text-yellow-600 dark:text-yellow-400';
+        return 'text-red-600 dark:text-red-400';
+    };
+
+    const getLatencyBg = (seconds: number) => {
+        if (seconds < 2) return 'bg-green-500/10 border-green-500/20';
+        if (seconds < 3) return 'bg-yellow-500/10 border-yellow-500/20';
+        return 'bg-red-500/10 border-red-500/20';
+    };
+
+    const getLatencyLabel = (seconds: number) => {
+        if (seconds < 2) return 'Fast';
+        if (seconds < 3) return 'Moderate';
+        return 'Slow';
     };
 
     if (loading) return <div className="p-8 text-center text-muted-foreground">Loading configuration...</div>;
@@ -320,6 +369,51 @@ const StreamingPage = () => {
                             onChange={(e) => updateStreamingConfig('egress_force_mulaw', e.target.checked)}
                             tooltip="Force μ-law (G.711) encoding for all downstream audio. Enable if Asterisk expects μ-law but provider sends PCM16. Typically needed for telephony compatibility."
                         />
+                    </div>
+                </ConfigCard>
+            </ConfigSection>
+
+            <ConfigSection title="Estimated Latency" description="Live estimate of first-byte latency based on current settings. Updates as you change options below.">
+                <ConfigCard className={`border ${getLatencyBg(latencyEstimate.actual)}`}>
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                            <Clock className={`w-6 h-6 ${getLatencyColor(latencyEstimate.actual)}`} />
+                            <div>
+                                <div className="flex items-baseline gap-2">
+                                    <span className={`text-3xl font-bold ${getLatencyColor(latencyEstimate.actual)}`}>
+                                        ~{latencyEstimate.actual.toFixed(1)}s
+                                    </span>
+                                    <span className={`text-sm font-medium ${getLatencyColor(latencyEstimate.actual)}`}>
+                                        {getLatencyLabel(latencyEstimate.actual)}
+                                    </span>
+                                </div>
+                                <p className="text-xs text-muted-foreground mt-0.5">
+                                    Estimated first-byte latency (actual)
+                                </p>
+                            </div>
+                        </div>
+                        {latencyEstimate.fillerEnabled && (
+                            <div className="text-right">
+                                <div className={`text-2xl font-bold ${getLatencyColor(latencyEstimate.perceived)}`}>
+                                    ~{latencyEstimate.perceived.toFixed(1)}s
+                                </div>
+                                <p className="text-xs text-muted-foreground">perceived (with filler)</p>
+                            </div>
+                        )}
+                    </div>
+                    <div className="mt-4 grid grid-cols-3 gap-2 text-xs text-muted-foreground border-t border-border/50 pt-3">
+                        <div className="flex items-center gap-1">
+                            <span className="w-2 h-2 rounded-full bg-green-500 inline-block" />
+                            &lt;2s Fast
+                        </div>
+                        <div className="flex items-center gap-1">
+                            <span className="w-2 h-2 rounded-full bg-yellow-500 inline-block" />
+                            2–3s Moderate
+                        </div>
+                        <div className="flex items-center gap-1">
+                            <span className="w-2 h-2 rounded-full bg-red-500 inline-block" />
+                            &gt;3s Slow
+                        </div>
                     </div>
                 </ConfigCard>
             </ConfigSection>

--- a/admin_ui/frontend/src/pages/Advanced/StreamingPage.tsx
+++ b/admin_ui/frontend/src/pages/Advanced/StreamingPage.tsx
@@ -101,6 +101,11 @@ const StreamingPage = () => {
         });
     };
 
+    const toFiniteNumber = (v: unknown, fallback: number): number => {
+        const n = Number(v);
+        return Number.isFinite(n) ? n : fallback;
+    };
+
     const latencyEstimate = useMemo(() => {
         const sc = config.streaming || {};
         // Base latency: STT recognition + LLM inference + TTS synthesis
@@ -115,15 +120,15 @@ const StreamingPage = () => {
         const fillerEnabled = sc.pipeline_filler_enabled ?? false;
 
         // Jitter buffer adds proportional delay (baseline 950ms)
-        const jitterMs = sc.jitter_buffer_ms ?? 950;
+        const jitterMs = toFiniteNumber(sc.jitter_buffer_ms, 950);
         estimated += (jitterMs - 950) / 1000;
 
         // Min start threshold affects when playback begins (baseline 120ms)
-        const minStartMs = sc.min_start_ms ?? 120;
+        const minStartMs = toFiniteNumber(sc.min_start_ms, 120);
         estimated += (minStartMs - 120) / 1000;
 
         // Low watermark affects buffering delay (baseline 80ms)
-        const lowWatermarkMs = sc.low_watermark_ms ?? 80;
+        const lowWatermarkMs = toFiniteNumber(sc.low_watermark_ms, 80);
         estimated += (lowWatermarkMs - 80) / 1000;
 
         const actual = Math.max(0.5, estimated);
@@ -134,19 +139,19 @@ const StreamingPage = () => {
 
     const getLatencyColor = (seconds: number) => {
         if (seconds < 2) return 'text-green-600 dark:text-green-400';
-        if (seconds < 3) return 'text-yellow-600 dark:text-yellow-400';
+        if (seconds <= 3) return 'text-yellow-600 dark:text-yellow-400';
         return 'text-red-600 dark:text-red-400';
     };
 
     const getLatencyBg = (seconds: number) => {
         if (seconds < 2) return 'bg-green-500/10 border-green-500/20';
-        if (seconds < 3) return 'bg-yellow-500/10 border-yellow-500/20';
+        if (seconds <= 3) return 'bg-yellow-500/10 border-yellow-500/20';
         return 'bg-red-500/10 border-red-500/20';
     };
 
     const getLatencyLabel = (seconds: number) => {
         if (seconds < 2) return 'Fast';
-        if (seconds < 3) return 'Moderate';
+        if (seconds <= 3) return 'Moderate';
         return 'Slow';
     };
 


### PR DESCRIPTION
## Summary

Closes #309

Adds a **live latency estimate card** to the Streaming Settings page that updates reactively as the user changes streaming options, giving instant feedback on how their configuration affects perceived response speed.

## What's added

- **"Estimated Latency" section** inserted above the Latency Optimization controls
- **Real-time `useMemo` calculation** — rerenders whenever any streaming config key changes
- **Color-coded display**: green (<2s Fast), yellow (2–3s Moderate), red (>3s Slow)
- **Dual readout** when filler audio is enabled — shows both *actual* and *perceived* latency side by side
- **Legend row** explaining the three color thresholds

## Calculation logic

| Setting | Effect |
|---|---|
| `pipeline_streaming_overlap` ON | −1.0s (LLM→TTS parallelism) |
| `pipeline_filler_enabled` ON | perceived −0.7s |
| `jitter_buffer_ms` | delta from 950 ms baseline |
| `min_start_ms` | delta from 120 ms baseline |
| `low_watermark_ms` | delta from 80 ms baseline |

## Test plan

- [ ] Open Streaming Settings page — estimate card visible
- [ ] Toggle **LLM→TTS Streaming Overlap** — estimate drops ~1s
- [ ] Enable **Pipeline Filler Audio** — "perceived" column appears
- [ ] Adjust **Jitter Buffer** slider — estimate updates instantly
- [ ] Adjust **Min Start** — estimate updates instantly
- [ ] Verify color transitions: <2s green, 2–3s yellow, >3s red

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Estimated Latency" display to the Streaming configuration page with color-coded visual indicators for quick assessment.
  * Shows actual and perceived latency metrics when applicable, presented as concise values in a config card.
  * Includes qualitative labels (Fast/Moderate/Slow) and a reference legend for latency ranges to aid interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->