### PR TITLE
feat: add Clone/Duplicate button for Contexts, Pipelines, and Profiles (closes #306)

### DIFF
--- a/admin_ui/frontend/src/pages/ContextsPage.tsx
+++ b/admin_ui/frontend/src/pages/ContextsPage.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import yaml from 'js-yaml';
 import { sanitizeConfigForSave } from '../utils/configSanitizers';
-import { Plus, Settings, Trash2, MessageSquare, AlertCircle, RefreshCw, Loader2 } from 'lucide-react';
+import { Plus, Settings, Trash2, Copy, MessageSquare, AlertCircle, RefreshCw, Loader2 } from 'lucide-react';
 import { YamlErrorBanner } from '../components/ui/YamlErrorBanner';
 import { ConfigSection } from '../components/ui/ConfigSection';
 import { ConfigCard } from '../components/ui/ConfigCard';
@@ -288,6 +288,19 @@ const ContextsPage = () => {
         await saveConfig({ ...config, contexts: newContexts });
     };
 
+    const handleCloneContext = (name: string) => {
+        const existingContexts = Object.keys(config.contexts || {});
+        let cloneName = `${name}_copy`;
+        let counter = 2;
+        while (existingContexts.includes(cloneName)) {
+            cloneName = `${name}_copy_${counter}`;
+            counter++;
+        }
+        setEditingContext(cloneName);
+        setContextForm({ name: cloneName, ...config.contexts?.[name] });
+        setIsNewContext(true);
+    };
+
     const handleSaveContext = async () => {
         if (!contextForm.name) return;
 
@@ -464,6 +477,13 @@ const ContextsPage = () => {
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                    <button
+                                        onClick={() => handleCloneContext(name)}
+                                        className="p-2 hover:bg-accent rounded-md text-muted-foreground hover:text-foreground"
+                                        title="Clone context"
+                                    >
+                                        <Copy className="w-4 h-4" />
+                                    </button>
                                     <button
                                         onClick={() => handleEditContext(name)}
                                         className="p-2 hover:bg-accent rounded-md text-muted-foreground hover:text-foreground"

--- a/admin_ui/frontend/src/pages/PipelinesPage.tsx
+++ b/admin_ui/frontend/src/pages/PipelinesPage.tsx
@@ -259,6 +259,13 @@ const PipelinesPage = () => {
         const pipelineName = isNewPipeline ? pipelineForm.name : editingPipeline;
         if (!pipelineName) return;
 
+        if (isNewPipeline && config.pipelines?.[pipelineName]) {
+            toast.error(`Pipeline '${pipelineName}' already exists`, {
+                description: 'Please choose a different name to avoid overwriting the existing pipeline.'
+            });
+            return;
+        }
+
         const normalizedForm = {
             ...pipelineForm,
             stt: ensureModularKey(pipelineForm.stt || '', 'stt'),

--- a/admin_ui/frontend/src/pages/PipelinesPage.tsx
+++ b/admin_ui/frontend/src/pages/PipelinesPage.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import yaml from 'js-yaml';
 import { sanitizeConfigForSave } from '../utils/configSanitizers';
-import { Plus, Settings, Trash2, ArrowRight, Workflow, AlertTriangle, AlertCircle, RefreshCw, Loader2 } from 'lucide-react';
+import { Plus, Settings, Trash2, Copy, ArrowRight, Workflow, AlertTriangle, AlertCircle, RefreshCw, Loader2 } from 'lucide-react';
 import { YamlErrorBanner, YamlErrorInfo } from '../components/ui/YamlErrorBanner';
 import { ConfigSection } from '../components/ui/ConfigSection';
 import { ConfigCard } from '../components/ui/ConfigCard';
@@ -202,6 +202,21 @@ const PipelinesPage = () => {
                 tts: { format: { encoding: 'mulaw', sample_rate: 8000 } }
             }
         });
+        setIsNewPipeline(true);
+    };
+
+    const handleClonePipeline = (name: string) => {
+        const existingPipelines = Object.keys(config.pipelines || {});
+        let cloneName = `${name}_copy`;
+        let counter = 2;
+        while (existingPipelines.includes(cloneName)) {
+            cloneName = `${name}_copy_${counter}`;
+            counter++;
+        }
+        const existing = config.pipelines?.[name] || {};
+        const { tools: _legacyTools, ...rest } = (existing && typeof existing === 'object') ? existing : {};
+        setEditingPipeline(cloneName);
+        setPipelineForm({ name: cloneName, ...rest });
         setIsNewPipeline(true);
     };
 
@@ -497,6 +512,13 @@ const PipelinesPage = () => {
                                     )}
                                 </div>
                                 <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                    <button
+                                        onClick={() => handleClonePipeline(name)}
+                                        className="p-2 hover:bg-accent rounded-md text-muted-foreground hover:text-foreground"
+                                        title="Clone pipeline"
+                                    >
+                                        <Copy className="w-4 h-4" />
+                                    </button>
                                     <button
                                         onClick={() => handleEditPipeline(name)}
                                         className="p-2 hover:bg-accent rounded-md text-muted-foreground hover:text-foreground"

--- a/admin_ui/frontend/src/pages/ProfilesPage.tsx
+++ b/admin_ui/frontend/src/pages/ProfilesPage.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import yaml from 'js-yaml';
 import { sanitizeConfigForSave } from '../utils/configSanitizers';
-import { Settings, Radio, Star, AlertCircle, RefreshCw, Loader2, Plus, Trash2 } from 'lucide-react';
+import { Settings, Radio, Star, AlertCircle, RefreshCw, Loader2, Plus, Trash2, Copy } from 'lucide-react';
 import { YamlErrorBanner, YamlErrorInfo } from '../components/ui/YamlErrorBanner';
 import { ConfigSection } from '../components/ui/ConfigSection';
 import { ConfigCard } from '../components/ui/ConfigCard';
@@ -204,6 +204,20 @@ const ProfilesPage = () => {
         return descriptions[profileName] || 'Custom audio profile';
     };
 
+    const handleCloneProfile = (profileName: string) => {
+        const existingProfiles = Object.keys(config.profiles || {}).filter(k => k !== 'default');
+        let cloneName = `${profileName}_copy`;
+        let counter = 2;
+        while (existingProfiles.includes(cloneName)) {
+            cloneName = `${profileName}_copy_${counter}`;
+            counter++;
+        }
+        setEditingProfile('new_profile');
+        setProfileForm({ ...config.profiles?.[profileName] });
+        setIsNewProfile(true);
+        setNewProfileName(cloneName);
+    };
+
     const handleDeleteProfile = async (profileName: string) => {
         const currentProfiles = config.profiles || {};
         const currentProfileKeys = Object.keys(currentProfiles).filter((k) => k !== 'default');
@@ -384,6 +398,16 @@ const ProfilesPage = () => {
                                         </div>
                                     </div>
 	                                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+	                                        <button
+	                                            onClick={(e) => {
+	                                                e.stopPropagation();
+	                                                handleCloneProfile(profileName);
+	                                            }}
+	                                            className="p-2 hover:bg-accent rounded-md text-muted-foreground hover:text-foreground"
+	                                            title="Clone profile"
+	                                        >
+	                                            <Copy className="w-4 h-4" />
+	                                        </button>
 	                                        <button
 	                                            onClick={(e) => {
 	                                                e.stopPropagation();


### PR DESCRIPTION
## Summary

Adds a **Clone** (copy icon) button to every Context, Pipeline, and Profile card so users can quickly duplicate an existing configuration.

### Changes

- **ContextsPage.tsx**: Added `handleCloneContext()` + Copy icon button
- **PipelinesPage.tsx**: Added `handleClonePipeline()` + Copy icon button  
- **ProfilesPage.tsx**: Added `handleCloneProfile()` + Copy icon button

### How it works

1. Click the copy icon on any card
2. The create form opens pre-populated with the source item's full settings
3. Name is auto-generated as `<original>_copy` (or `_copy_2`, `_copy_3` on collision)
4. User can modify any field before saving as a new independent entry

### Acceptance Criteria

- [x] Each Context, Pipeline, and Profile card has a visible Clone/Duplicate button
- [x] Clicking it opens the create form pre-filled with the source item's configuration
- [x] The cloned item has a unique name (e.g., `my_context_copy`)
- [x] Saving the cloned item creates an independent new entry

Closes #306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Clone" action for contexts, pipelines, and profiles so users can duplicate items with auto-generated unique names.
* **Bug Fixes**
  * Prevented accidental overwrites when creating cloned pipelines by blocking duplicate names and showing an error notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->