### PR TITLE
feat: add log export/download button to System Logs page (closes #316)

### DIFF
--- a/admin_ui/frontend/src/pages/Logs.tsx
+++ b/admin_ui/frontend/src/pages/Logs.tsx
@@ -38,6 +38,31 @@ const Logs = () => {
         }
     }, [logs, autoRefresh]);
 
+    const getFilteredLines = (): string[] => {
+        if (!logs) return [];
+        return logs.split('\n').filter(line =>
+            !filter || line.toLowerCase().includes(filter.toLowerCase())
+        );
+    };
+
+    const handleDownload = () => {
+        const lines = getFilteredLines();
+        if (lines.length === 0) {
+            return;
+        }
+        const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        const filename = `ava-${container}-${ts}.log`;
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    };
+
     const getColoredLogs = () => {
         if (!logs) return <div className="text-muted-foreground italic">No logs available...</div>;
 
@@ -92,6 +117,14 @@ const Logs = () => {
                         title={autoRefresh ? "Pause Auto-refresh" : "Resume Auto-refresh"}
                     >
                         {autoRefresh ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+                    </button>
+
+                    <button
+                        onClick={handleDownload}
+                        className="p-2 rounded border border-input hover:bg-accent"
+                        title="Download Logs"
+                    >
+                        <Download className="w-4 h-4" />
                     </button>
 
                     <button

--- a/admin_ui/frontend/src/pages/Logs.tsx
+++ b/admin_ui/frontend/src/pages/Logs.tsx
@@ -48,6 +48,7 @@ const Logs = () => {
     const handleDownload = () => {
         const lines = getFilteredLines();
         if (lines.length === 0) {
+            alert('No logs available to export. Adjust filters and try again.');
             return;
         }
         const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
@@ -64,11 +65,12 @@ const Logs = () => {
     };
 
     const getColoredLogs = () => {
-        if (!logs) return <div className="text-muted-foreground italic">No logs available...</div>;
+        const filteredLines = getFilteredLines();
+        if (!logs || filteredLines.length === 0) {
+            return <div className="text-muted-foreground italic">No logs available...</div>;
+        }
 
-        return logs.split('\n').map((line, i) => {
-            if (filter && !line.toLowerCase().includes(filter.toLowerCase())) return null;
-
+        return filteredLines.map((line, i) => {
             let className = 'text-green-400'; // Default
             if (line.includes('ERROR') || line.includes('Exception') || line.includes('CRITICAL')) {
                 className = 'text-red-500 font-bold';


### PR DESCRIPTION
## Summary

Closes #316

Adds a **Download** button to the System Logs page that exports the currently displayed and filtered logs as a `.log` text file.

## Changes

- Wire up the already-imported but unused `Download` icon
- Add `getFilteredLines()` helper to extract visible log lines
- Add `handleDownload()` that creates a Blob download with container name + ISO timestamp filename (e.g. `ava-ai_engine-2026-04-11T10-30-00.log`)
- Button placed between Pause/Play and Refresh controls

## How it works

1. Click the download icon button in the toolbar
2. Currently filtered logs are packaged into a text file
3. Browser triggers a download with a descriptive filename

Respects the active filter — only visible lines are exported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Download Logs" button allowing users to export the currently filtered logs as a plain text file.
* **Bug Fixes / Improvements**
  * Ensured the logs shown in the UI match the content exported.
  * Alerts the user when there are no filtered logs to download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->