### PR TITLE
feat: show estimated token count in Context instructions editor (closes #305)

### DIFF
--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -127,7 +127,7 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
     };
 
     const estimatedTokens = useMemo(() => {
-        const text = config.prompt || '';
+        const text = typeof config.prompt === 'string' ? config.prompt : String(config.prompt ?? '');
         if (!text.trim()) return 0;
         const words = text.split(/\s+/).filter(Boolean).length;
         return Math.round(words * 1.3);

--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -18,6 +18,9 @@ interface ContextFormProps {
     isNew?: boolean;
 }
 
+const TOKEN_WARN_LIMIT = 4000;
+const TOKEN_HARD_LIMIT = 8000;
+
 const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabledMap, toolCatalogByName, availableProfiles, defaultProfileName, httpTools, onChange, isNew }: ContextFormProps) => {
     const [expandedPhases, setExpandedPhases] = useState<Record<string, boolean>>({
         pre_call: false,
@@ -135,8 +138,8 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
 
     const tokenCountColor = useMemo(() => {
         if (estimatedTokens === 0) return 'text-muted-foreground';
-        if (estimatedTokens > 8000) return 'text-red-500';
-        if (estimatedTokens > 4000) return 'text-yellow-500';
+        if (estimatedTokens > TOKEN_HARD_LIMIT) return 'text-red-500';
+        if (estimatedTokens > TOKEN_WARN_LIMIT) return 'text-yellow-500';
         return 'text-muted-foreground';
     }, [estimatedTokens]);
 
@@ -199,8 +202,8 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
                 <div className="flex items-center justify-between mt-1">
                     <span className={`text-xs ${tokenCountColor}`}>
                         ~{estimatedTokens.toLocaleString()} tokens estimated
-                        {estimatedTokens > 8000 && ' — exceeds typical 8K context limit'}
-                        {estimatedTokens > 4000 && estimatedTokens <= 8000 && ' — approaching 8K context limit'}
+                        {estimatedTokens > TOKEN_HARD_LIMIT && ' — exceeds typical 8K context limit'}
+                        {estimatedTokens > TOKEN_WARN_LIMIT && estimatedTokens <= TOKEN_HARD_LIMIT && ' — approaching 8K context limit'}
                     </span>
                 </div>
             </div>

--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -1,7 +1,7 @@
 import { FormInput, FormSelect, FormLabel } from '../ui/FormComponents';
 import { isFullAgentProvider } from '../../utils/providerNaming';
 import { ChevronDown, ChevronRight, Search, Phone, Webhook, Lock } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import HelpTooltip from '../ui/HelpTooltip';
 
 interface ContextFormProps {
@@ -126,6 +126,20 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
         return toolEnabledMap[tool] === false;
     };
 
+    const estimatedTokens = useMemo(() => {
+        const text = config.prompt || '';
+        if (!text.trim()) return 0;
+        const words = text.split(/\s+/).filter(Boolean).length;
+        return Math.round(words * 1.3);
+    }, [config.prompt]);
+
+    const tokenCountColor = useMemo(() => {
+        if (estimatedTokens === 0) return 'text-muted-foreground';
+        if (estimatedTokens > 8000) return 'text-red-500';
+        if (estimatedTokens > 4000) return 'text-yellow-500';
+        return 'text-muted-foreground';
+    }, [estimatedTokens]);
+
     const pipelineOptions = Object.entries(pipelines || {}).map(([name, _]: [string, any]) => ({
         value: `pipeline:${name}`,
         label: `[Pipeline] ${name}`,
@@ -182,6 +196,13 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
                     onChange={(e) => updateConfig('prompt', e.target.value)}
                     placeholder="You are a helpful voice assistant..."
                 />
+                <div className="flex items-center justify-between mt-1">
+                    <span className={`text-xs ${tokenCountColor}`}>
+                        ~{estimatedTokens.toLocaleString()} tokens estimated
+                        {estimatedTokens > 8000 && ' — exceeds typical 8K context limit'}
+                        {estimatedTokens > 4000 && estimatedTokens <= 8000 && ' — approaching 8K context limit'}
+                    </span>
+                </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary

Adds a live estimated token count display below the System Prompt textarea in the Context Form.

### Changes
- Token estimation using lightweight heuristic (~words x 1.3)
- Live updates as user types
- Color-coded warnings: gray (normal), yellow (>4K), red (>8K)
- Zero external dependencies, ~20 lines in ContextForm.tsx

## Test Plan
- [ ] Token count updates live while typing
- [ ] Shows 0 for empty prompt
- [ ] Yellow warning for >4K tokens
- [ ] Red warning for >8K tokens

Closes #305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows an inline estimated token count under the System Prompt textarea in the configuration form.
  * Adds color-coded warnings and contextual suffixes for token levels: a caution around 4,000 tokens and a stronger warning when exceeding ~8,000 tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->