### PR TITLE
feat: add dark/light/system theme toggle to Admin UI (closes #321)

### DIFF
--- a/admin_ui/frontend/index.html
+++ b/admin_ui/frontend/index.html
@@ -6,6 +6,14 @@
   <link rel="icon" type="image/png" href="/favicon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Asterisk AI Agent Admin</title>
+  <script>
+    // Apply saved theme before first paint to prevent flash
+    (function() {
+      var t = localStorage.getItem('ava-theme') || 'system';
+      var dark = t === 'dark' || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+      if (dark) document.documentElement.classList.add('dark');
+    })();
+  </script>
 </head>
 
 <body>

--- a/admin_ui/frontend/src/components/layout/Header.tsx
+++ b/admin_ui/frontend/src/components/layout/Header.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Sun, Moon, Monitor } from 'lucide-react';
+import { useTheme } from '../../hooks/useTheme';
 
 const Header = () => {
     const location = useLocation();
+    const { theme, cycleTheme } = useTheme();
     const pathSegments = location.pathname.split('/').filter(Boolean);
 
     const getBreadcrumbName = (segment: string) => {
@@ -38,8 +40,16 @@ const Header = () => {
                 ))}
             </div>
 
-            {/* Global actions removed - pages handle their own saving */}
             <div className="flex items-center gap-2">
+                <button
+                    onClick={cycleTheme}
+                    className="p-2 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+                    title={`Theme: ${theme} (click to cycle)`}
+                >
+                    {theme === 'light' && <Sun className="w-4 h-4" />}
+                    {theme === 'dark' && <Moon className="w-4 h-4" />}
+                    {theme === 'system' && <Monitor className="w-4 h-4" />}
+                </button>
             </div>
         </header>
     );

--- a/admin_ui/frontend/src/components/layout/Header.tsx
+++ b/admin_ui/frontend/src/components/layout/Header.tsx
@@ -42,10 +42,11 @@ const Header = () => {
 
             <div className="flex items-center gap-2">
                 <button
+                    type="button"
                     onClick={cycleTheme}
                     className="p-2 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
                     title={`Theme: ${theme} (click to cycle)`}
-                    aria-label={`Current theme: ${theme}. Click to cycle theme`}
+                    aria-label={`Current theme: ${theme}. Activate to cycle theme`}
                 >
                     {theme === 'light' && <Sun className="w-4 h-4" />}
                     {theme === 'dark' && <Moon className="w-4 h-4" />}

--- a/admin_ui/frontend/src/components/layout/Header.tsx
+++ b/admin_ui/frontend/src/components/layout/Header.tsx
@@ -45,6 +45,7 @@ const Header = () => {
                     onClick={cycleTheme}
                     className="p-2 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
                     title={`Theme: ${theme} (click to cycle)`}
+                    aria-label={`Current theme: ${theme}. Click to cycle theme`}
                 >
                     {theme === 'light' && <Sun className="w-4 h-4" />}
                     {theme === 'dark' && <Moon className="w-4 h-4" />}

--- a/admin_ui/frontend/src/hooks/useTheme.ts
+++ b/admin_ui/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+const STORAGE_KEY = 'ava-theme';
+
+function getSystemTheme(): 'light' | 'dark' {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+    const resolved = theme === 'system' ? getSystemTheme() : theme;
+    document.documentElement.classList.toggle('dark', resolved === 'dark');
+}
+
+export function useTheme() {
+    const [theme, setThemeState] = useState<Theme>(() => {
+        const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+        return stored && ['light', 'dark', 'system'].includes(stored) ? stored : 'system';
+    });
+
+    useEffect(() => {
+        applyTheme(theme);
+        localStorage.setItem(STORAGE_KEY, theme);
+    }, [theme]);
+
+    // Listen for OS theme changes when in system mode
+    useEffect(() => {
+        const mq = window.matchMedia('(prefers-color-scheme: dark)');
+        const handler = () => {
+            if (theme === 'system') applyTheme('system');
+        };
+        mq.addEventListener('change', handler);
+        return () => mq.removeEventListener('change', handler);
+    }, [theme]);
+
+    const setTheme = (t: Theme) => setThemeState(t);
+
+    const cycleTheme = () => {
+        const order: Theme[] = ['light', 'dark', 'system'];
+        const next = order[(order.indexOf(theme) + 1) % order.length];
+        setTheme(next);
+    };
+
+    return { theme, setTheme, cycleTheme };
+}


### PR DESCRIPTION
## Summary

Adds a theme toggle button to the Admin UI header that cycles between Light, Dark, and System modes.

## Changes

- **`useTheme` hook** (`src/hooks/useTheme.ts`): Manages theme state with `localStorage` persistence and OS preference detection via `prefers-color-scheme` media query
- **Header component**: Added a cycle button with contextual icons (Sun = light, Moon = dark, Monitor = system)
- **`index.html`**: Inline `<script>` applies the saved theme before first paint to prevent flash of wrong theme (FOUC)

## How It Works

1. Click the icon in the top-right header to cycle: Light → Dark → System
2. The `dark` class is toggled on `<html>`, which activates the existing `.dark` CSS variables already defined in `index.css`
3. Preference is saved to `localStorage` and restored on reload
4. In System mode, the theme follows the OS preference and updates live if the user changes their OS setting

## Screenshots

The existing dark theme variables in `index.css` are now accessible to users — no CSS changes needed.

Closes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theme toggle in the header to switch light, dark, and system modes.
  * Theme preference is persisted and applied before initial paint to avoid flicker.
  * When set to system, the app now follows OS theme changes in real time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->