### PR TITLE
feat: show estimated token count in Context instructions editor (closes #305)

### DIFF
--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -19,14 +19,15 @@ interface ContextFormProps {
 }
 
 const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabledMap, toolCatalogByName, availableProfiles, defaultProfileName, httpTools, onChange, isNew }: ContextFormProps) => {
-    const estimateTokens = (text: string): number => {
-        if (!text) return 0;
+    const estimateTokens = (text: unknown): number => {
+        const normalized = typeof text === 'string' ? text : String(text ?? '');
+        if (!normalized.trim()) return 0;
         // Heuristic: ~1.3 tokens per word, accounts for punctuation and whitespace tokens
-        const words = text.trim().split(/\s+/).filter(Boolean).length;
+        const words = normalized.trim().split(/\s+/).filter(Boolean).length;
         return Math.round(words * 1.3);
     };
 
-    const promptTokens = useMemo(() => estimateTokens(config.prompt || ''), [config.prompt]);
+    const promptTokens = useMemo(() => estimateTokens(config.prompt), [config.prompt]);
 
     const tokenCountColor = promptTokens > 8000
         ? 'text-red-400'

--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -1,7 +1,7 @@
 import { FormInput, FormSelect, FormLabel } from '../ui/FormComponents';
 import { isFullAgentProvider } from '../../utils/providerNaming';
 import { ChevronDown, ChevronRight, Search, Phone, Webhook, Lock } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import HelpTooltip from '../ui/HelpTooltip';
 
 interface ContextFormProps {
@@ -19,6 +19,21 @@ interface ContextFormProps {
 }
 
 const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabledMap, toolCatalogByName, availableProfiles, defaultProfileName, httpTools, onChange, isNew }: ContextFormProps) => {
+    const estimateTokens = (text: string): number => {
+        if (!text) return 0;
+        // Heuristic: ~1.3 tokens per word, accounts for punctuation and whitespace tokens
+        const words = text.trim().split(/\s+/).filter(Boolean).length;
+        return Math.round(words * 1.3);
+    };
+
+    const promptTokens = useMemo(() => estimateTokens(config.prompt || ''), [config.prompt]);
+
+    const tokenCountColor = promptTokens > 8000
+        ? 'text-red-400'
+        : promptTokens > 4000
+            ? 'text-yellow-400'
+            : 'text-muted-foreground';
+
     const [expandedPhases, setExpandedPhases] = useState<Record<string, boolean>>({
         pre_call: false,
         in_call: true,
@@ -182,6 +197,10 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
                     onChange={(e) => updateConfig('prompt', e.target.value)}
                     placeholder="You are a helpful voice assistant..."
                 />
+                <div className={`text-xs ${tokenCountColor} mt-1 text-right`}>
+                    ~{promptTokens.toLocaleString()} tokens estimated
+                    {promptTokens > 8000 && ' ⚠ large prompt'}
+                </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -198,9 +198,13 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
                     onChange={(e) => updateConfig('prompt', e.target.value)}
                     placeholder="You are a helpful voice assistant..."
                 />
-                <div className={`text-xs ${tokenCountColor} mt-1 text-right`}>
+                <div className={`text-xs ${tokenCountColor} mt-1 text-right`} aria-live="polite">
                     ~{promptTokens.toLocaleString()} tokens estimated
-                    {promptTokens > 8000 && ' ⚠ large prompt'}
+                    {promptTokens > 8000
+                        ? ' ⚠ large prompt'
+                        : promptTokens > 4000
+                            ? ' • approaching limit'
+                            : ''}
                 </div>
             </div>
 

--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -29,8 +29,16 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
 
     const promptTokens = useMemo(() => estimateTokens(config.prompt), [config.prompt]);
 
-    const promptHardLimit = Number(config?.prompt_token_limit ?? 8000);
-    const promptWarnLimit = Number(config?.prompt_token_warn_limit ?? Math.floor(promptHardLimit * 0.5));
+    const toPositiveInt = (value: unknown, fallback: number): number => {
+        const parsed = typeof value === 'number' ? value : Number(value);
+        return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+    };
+
+    const promptHardLimit = toPositiveInt(config?.prompt_token_limit, 8000);
+    const promptWarnLimit = Math.min(
+        toPositiveInt(config?.prompt_token_warn_limit, Math.floor(promptHardLimit * 0.5)),
+        promptHardLimit
+    );
 
     const tokenCountColor = promptTokens > promptHardLimit
         ? 'text-red-400'

--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -29,9 +29,12 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
 
     const promptTokens = useMemo(() => estimateTokens(config.prompt), [config.prompt]);
 
-    const tokenCountColor = promptTokens > 8000
+    const promptHardLimit = Number(config?.prompt_token_limit ?? 8000);
+    const promptWarnLimit = Number(config?.prompt_token_warn_limit ?? Math.floor(promptHardLimit * 0.5));
+
+    const tokenCountColor = promptTokens > promptHardLimit
         ? 'text-red-400'
-        : promptTokens > 4000
+        : promptTokens > promptWarnLimit
             ? 'text-yellow-400'
             : 'text-muted-foreground';
 
@@ -200,9 +203,9 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
                 />
                 <div className={`text-xs ${tokenCountColor} mt-1 text-right`} aria-live="polite">
                     ~{promptTokens.toLocaleString()} tokens estimated
-                    {promptTokens > 8000
-                        ? ' ⚠ large prompt'
-                        : promptTokens > 4000
+                    {promptTokens > promptHardLimit
+                        ? ` ⚠ exceeds ~${promptHardLimit.toLocaleString()} token budget`
+                        : promptTokens > promptWarnLimit
                             ? ' • approaching limit'
                             : ''}
                 </div>


### PR DESCRIPTION
## Summary

- Adds a live estimated token count below the system prompt textarea in the Context Form
- Uses a lightweight heuristic (~words × 1.3) for fast client-side estimation
- Shows color-coded warnings: default gray → yellow at 4K tokens → red at 8K tokens
- Updates in real-time as the user types using `useMemo` for efficient recalculation

Closes #305

## Changes

- `admin_ui/frontend/src/components/config/ContextForm.tsx`: Added `estimateTokens` helper, `useMemo`-based token count, and color-coded display span below textarea

## Test plan

- [ ] Open the Context editor and type in the system prompt field
- [ ] Verify the token count updates live as you type
- [ ] Verify the count shows in gray for small prompts, yellow above ~4K tokens, red above ~8K tokens
- [ ] Verify the warning text appears when tokens exceed 8K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline, real-time estimated token count for System Prompt inputs.
  * Color-coded feedback: red for exceeding hard limit, yellow for approaching limit, muted for safe.
  * Right-aligned informational line under the System Prompt showing count and contextual warning when estimates approach or exceed limits; announced politely for screen readers.
  * Default hard limit set to 8000 with a warn threshold at ~50% and safeguards to keep warning limits within the hard limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->