### PR TITLE
feat: show estimated token count in Context instructions editor (closes #305)

### DIFF
--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -1,7 +1,7 @@
 import { FormInput, FormSelect, FormLabel } from '../ui/FormComponents';
 import { isFullAgentProvider } from '../../utils/providerNaming';
 import { ChevronDown, ChevronRight, Search, Phone, Webhook, Lock } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import HelpTooltip from '../ui/HelpTooltip';
 
 interface ContextFormProps {
@@ -126,6 +126,19 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
         return toolEnabledMap[tool] === false;
     };
 
+    const estimatedTokens = useMemo(() => {
+        const text = config.prompt || '';
+        if (!text.trim()) return 0;
+        const words = text.trim().split(/\s+/).length;
+        return Math.round(words * 1.3);
+    }, [config.prompt]);
+
+    const tokenCountColor = useMemo(() => {
+        if (estimatedTokens > 8000) return 'text-red-500';
+        if (estimatedTokens > 4000) return 'text-yellow-500';
+        return 'text-muted-foreground';
+    }, [estimatedTokens]);
+
     const pipelineOptions = Object.entries(pipelines || {}).map(([name, _]: [string, any]) => ({
         value: `pipeline:${name}`,
         label: `[Pipeline] ${name}`,
@@ -182,6 +195,13 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
                     onChange={(e) => updateConfig('prompt', e.target.value)}
                     placeholder="You are a helpful voice assistant..."
                 />
+                <div className="flex justify-end mt-1">
+                    <span className={`text-xs ${tokenCountColor}`}>
+                        ~{estimatedTokens.toLocaleString()} tokens estimated
+                        {estimatedTokens > 8000 && ' (exceeds 8K limit)'}
+                        {estimatedTokens > 4000 && estimatedTokens <= 8000 && ' (approaching 8K limit)'}
+                    </span>
+                </div>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/admin_ui/frontend/src/components/config/ContextForm.tsx
+++ b/admin_ui/frontend/src/components/config/ContextForm.tsx
@@ -134,8 +134,8 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
     }, [config.prompt]);
 
     const tokenCountColor = useMemo(() => {
-        if (estimatedTokens > 8000) return 'text-red-500';
-        if (estimatedTokens > 4000) return 'text-yellow-500';
+        if (estimatedTokens >= 8000) return 'text-red-500';
+        if (estimatedTokens >= 4000) return 'text-yellow-500';
         return 'text-muted-foreground';
     }, [estimatedTokens]);
 
@@ -198,8 +198,8 @@ const ContextForm = ({ config, providers, pipelines, availableTools, toolEnabled
                 <div className="flex justify-end mt-1">
                     <span className={`text-xs ${tokenCountColor}`}>
                         ~{estimatedTokens.toLocaleString()} tokens estimated
-                        {estimatedTokens > 8000 && ' (exceeds 8K limit)'}
-                        {estimatedTokens > 4000 && estimatedTokens <= 8000 && ' (approaching 8K limit)'}
+                        {estimatedTokens >= 8000 && ' (exceeds 8K limit)'}
+                        {estimatedTokens >= 4000 && estimatedTokens < 8000 && ' (approaching 8K limit)'}
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add live token count estimate below the System Prompt textarea in ContextForm
- Uses lightweight heuristic (`words × 1.3`) that updates on each keystroke
- Shows warning colors when approaching context limits (yellow at 4K, red at 8K)

Closes #305

## Changes
- `admin_ui/frontend/src/components/config/ContextForm.tsx`: Added `useMemo`-based token estimation with color-coded display

## Acceptance Criteria
- [x] Token count updates live as the user types
- [x] Count displayed below the textarea
- [x] Estimate uses `words × 1.3` heuristic (±10% accuracy)
- [x] Warning colors at 4K (yellow) and 8K (red) thresholds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an estimated token count shown beneath the System Prompt textarea, indicating approximately how many tokens your prompt will consume.
  * Added color-coded indicators (yellow when approaching 8K, red when exceeding 8K) and compact limit-state text to help monitor prompt size at a glance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->