### PR TITLE
feat: add log export/download button to System Logs page (closes #316)

### DIFF
--- a/admin_ui/frontend/src/pages/Logs.tsx
+++ b/admin_ui/frontend/src/pages/Logs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import axios from 'axios';
 import { RefreshCw, Download, Pause, Play, Search } from 'lucide-react';
 
@@ -38,15 +38,15 @@ const Logs = () => {
         }
     }, [logs, autoRefresh]);
 
-    const getFilteredLines = (): string[] => {
+    const filteredLines = useMemo(() => {
         if (!logs) return [];
         return logs.split('\n').filter(line =>
             !filter || line.toLowerCase().includes(filter.toLowerCase())
         );
-    };
+    }, [logs, filter]);
 
     const handleDownload = () => {
-        const lines = getFilteredLines();
+        const lines = filteredLines;
         if (lines.length === 0) return;
         const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
         const url = URL.createObjectURL(blob);
@@ -61,7 +61,7 @@ const Logs = () => {
     const getColoredLogs = () => {
         if (!logs) return <div className="text-muted-foreground italic">No logs available...</div>;
 
-        return getFilteredLines().map((line, i) => {
+        return filteredLines.map((line, i) => {
             let className = 'text-green-400'; // Default
             if (line.includes('ERROR') || line.includes('Exception') || line.includes('CRITICAL')) {
                 className = 'text-red-500 font-bold';
@@ -122,9 +122,9 @@ const Logs = () => {
 
                     <button
                         onClick={handleDownload}
-                        disabled={!logs}
+                        disabled={filteredLines.length === 0}
                         className="p-2 rounded border border-input hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
-                        title="Download Logs"
+                        title={filteredLines.length === 0 ? "No visible logs to download" : "Download Logs"}
                     >
                         <Download className="w-4 h-4" />
                     </button>

--- a/admin_ui/frontend/src/pages/Logs.tsx
+++ b/admin_ui/frontend/src/pages/Logs.tsx
@@ -38,12 +38,30 @@ const Logs = () => {
         }
     }, [logs, autoRefresh]);
 
+    const getFilteredLines = (): string[] => {
+        if (!logs) return [];
+        return logs.split('\n').filter(line =>
+            !filter || line.toLowerCase().includes(filter.toLowerCase())
+        );
+    };
+
+    const handleDownload = () => {
+        const lines = getFilteredLines();
+        if (lines.length === 0) return;
+        const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `ava-${container}-${timestamp}.log`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
     const getColoredLogs = () => {
         if (!logs) return <div className="text-muted-foreground italic">No logs available...</div>;
 
-        return logs.split('\n').map((line, i) => {
-            if (filter && !line.toLowerCase().includes(filter.toLowerCase())) return null;
-
+        return getFilteredLines().map((line, i) => {
             let className = 'text-green-400'; // Default
             if (line.includes('ERROR') || line.includes('Exception') || line.includes('CRITICAL')) {
                 className = 'text-red-500 font-bold';
@@ -100,6 +118,15 @@ const Logs = () => {
                         title="Refresh Now"
                     >
                         <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                    </button>
+
+                    <button
+                        onClick={handleDownload}
+                        disabled={!logs}
+                        className="p-2 rounded border border-input hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="Download Logs"
+                    >
+                        <Download className="w-4 h-4" />
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

Adds a **Download** button to the System Logs page that exports the currently displayed (and filtered) logs as a `.log` text file.

### Changes
- Add `getFilteredLines()` helper to share filtering logic between display and export
- Add `handleDownload()` that creates a Blob download with container name + timestamp in the filename (e.g. `ava-ai_engine-2026-04-12T10-30-00.log`)
- Add Download button next to the Refresh control, using the already-imported but unused `Download` icon from lucide-react
- Button is disabled when no logs are loaded
- Respects the current filter — only exports visible log lines

### Before / After
- **Before**: `Download` icon imported but unused; no way to export logs
- **After**: Download button appears in the toolbar; clicking it saves filtered logs as a `.log` file

Closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Download Logs" button to export currently filtered logs as text files, named with the container identifier and timestamp; button is disabled when no logs are visible.
* **Bug Fixes**
  * Improved log filtering and rendering to ensure consistent, accurate display of filtered log lines (no null/empty entries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->