### PR TITLE
feat: highlight filter matches and show line count in System Logs

### DIFF
--- a/admin_ui/frontend/src/pages/Logs.tsx
+++ b/admin_ui/frontend/src/pages/Logs.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import axios from 'axios';
-import { RefreshCw, Download, Pause, Play, Search } from 'lucide-react';
+import { RefreshCw, Download, Pause, Play, Search, ArrowDown } from 'lucide-react';
 
 const Logs = () => {
     const [logs, setLogs] = useState('');
@@ -38,12 +38,28 @@ const Logs = () => {
         }
     }, [logs, autoRefresh]);
 
-    const filteredLines = useMemo(() => {
+    const allLines = useMemo(() => {
         if (!logs) return [];
-        return logs.split('\n').filter(line =>
-            !filter || line.toLowerCase().includes(filter.toLowerCase())
+        return logs.split('\n');
+    }, [logs]);
+
+    const filteredLines = useMemo(() => {
+        if (!filter) return allLines;
+        return allLines.filter(line => line.toLowerCase().includes(filter.toLowerCase()));
+    }, [allLines, filter]);
+
+    const highlightMatch = (line: string, term: string): React.ReactNode => {
+        if (!term) return line;
+        const escapedTerm = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const regex = new RegExp(`(${escapedTerm})`, 'gi');
+        // split with a capturing group: odd indices are matches, even are non-matches
+        const parts = line.split(regex);
+        return parts.map((part, i) =>
+            i % 2 === 1
+                ? <mark key={i} className="bg-yellow-400/30 text-yellow-200 rounded px-0.5">{part}</mark>
+                : part
         );
-    }, [logs, filter]);
+    };
 
     const handleDownload = () => {
         const lines = filteredLines;
@@ -58,8 +74,13 @@ const Logs = () => {
         URL.revokeObjectURL(url);
     };
 
+    const scrollToBottom = () => {
+        logsEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    };
+
     const getColoredLogs = () => {
         if (!logs) return <div className="text-muted-foreground italic">No logs available...</div>;
+        if (filteredLines.length === 0) return <div className="text-muted-foreground italic">No lines match the filter.</div>;
 
         return filteredLines.map((line, i) => {
             let className = 'text-green-400'; // Default
@@ -73,7 +94,11 @@ const Logs = () => {
                 className = 'text-gray-500';
             }
 
-            return <div key={i} className={`${className} hover:bg-white/5 px-1 rounded`}>{line}</div>;
+            return (
+                <div key={i} className={`${className} hover:bg-white/5 px-1 rounded`}>
+                    {highlightMatch(line, filter)}
+                </div>
+            );
         });
     };
 
@@ -92,6 +117,13 @@ const Logs = () => {
                             onChange={e => setFilter(e.target.value)}
                         />
                     </div>
+                    {logs && (
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                            {filter
+                                ? `${filteredLines.length} / ${allLines.length} lines`
+                                : `${allLines.length} lines`}
+                        </span>
+                    )}
                 </div>
                 <div className="flex space-x-2 items-center">
                     <select
@@ -118,6 +150,14 @@ const Logs = () => {
                         title="Refresh Now"
                     >
                         <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                    </button>
+
+                    <button
+                        onClick={scrollToBottom}
+                        className="p-2 rounded border border-input hover:bg-accent"
+                        title="Scroll to Bottom"
+                    >
+                        <ArrowDown className="w-4 h-4" />
                     </button>
 
                     <button

--- a/admin_ui/frontend/src/pages/Logs.tsx
+++ b/admin_ui/frontend/src/pages/Logs.tsx
@@ -40,7 +40,10 @@ const Logs = () => {
 
     const allLines = useMemo(() => {
         if (!logs) return [];
-        return logs.split('\n');
+        const lines = logs.split('\n');
+        // Remove trailing empty element produced by a final newline
+        if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+        return lines;
     }, [logs]);
 
     const filteredLines = useMemo(() => {
@@ -156,6 +159,7 @@ const Logs = () => {
                         onClick={scrollToBottom}
                         className="p-2 rounded border border-input hover:bg-accent"
                         title="Scroll to Bottom"
+                        aria-label="Scroll to Bottom"
                     >
                         <ArrowDown className="w-4 h-4" />
                     </button>

--- a/admin_ui/frontend/src/pages/Logs.tsx
+++ b/admin_ui/frontend/src/pages/Logs.tsx
@@ -143,6 +143,7 @@ const Logs = () => {
                         onClick={() => setAutoRefresh(!autoRefresh)}
                         className={`p-2 rounded border ${autoRefresh ? 'bg-primary text-primary-foreground border-primary' : 'border-input hover:bg-accent'}`}
                         title={autoRefresh ? "Pause Auto-refresh" : "Resume Auto-refresh"}
+                        aria-label={autoRefresh ? "Pause Auto-refresh" : "Resume Auto-refresh"}
                     >
                         {autoRefresh ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
                     </button>
@@ -151,6 +152,7 @@ const Logs = () => {
                         onClick={fetchLogs}
                         className="p-2 rounded border border-input hover:bg-accent"
                         title="Refresh Now"
+                        aria-label="Refresh Now"
                     >
                         <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
                     </button>
@@ -169,6 +171,7 @@ const Logs = () => {
                         disabled={filteredLines.length === 0}
                         className="p-2 rounded border border-input hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed"
                         title={filteredLines.length === 0 ? "No visible logs to download" : "Download Logs"}
+                        aria-label={filteredLines.length === 0 ? "No visible logs to download" : "Download Logs"}
                     >
                         <Download className="w-4 h-4" />
                     </button>


### PR DESCRIPTION
## Summary

- **Filter match highlighting**: when a filter term is entered, matching text within each log line is highlighted in yellow, making it immediately visible *where* the term appears rather than just which lines contain it
- **Line count badge**: shows \`X / Y lines\` when filtering (filtered count vs total) or just \`Y lines\` total — gives instant feedback on filter results
- **Scroll to Bottom button**: new ArrowDown icon button for manual jump-to-bottom when auto-refresh is paused

## Changes

- \`admin_ui/frontend/src/pages/Logs.tsx\`
  - Split \`filteredLines\` memo into \`allLines\` + \`filteredLines\` to support the count badge
  - Added \`highlightMatch()\` helper using \`String.split\` with a capturing-group regex (avoids stateful regex bugs)
  - Added line count badge next to the filter input
  - Added \`scrollToBottom()\` function + ArrowDown button in toolbar
  - Added empty state message when filter matches no lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scroll-to-bottom button for quick, smooth log navigation.
  * Filter terms are highlighted in log lines for easier identification.
  * Header shows matched/total line count when a filter is active.
  * Clearer empty-state message when filtering yields no matching logs.
  * Download now respects the active filter (downloads visible lines).

* **Accessibility**
  * Improved ARIA labels for auto-refresh, refresh, scroll-to-bottom, and download controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->