### PR TITLE
feat(google-live): expand voice picker to 30 voices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Google Live voice picker — full 30-voice catalog (#349)**: Expanded the `google_live` TTS voice picker in the admin UI from 8 hardcoded voices (split arbitrarily into Female/Male) to the full 30-voice catalog that Gemini native-audio Live models support. Voices are labeled with Google's official tone descriptors (Bright, Firm, Smooth, Warm, etc.) from the [speech-generation docs](https://ai.google.dev/gemini-api/docs/speech-generation), listed alphabetically. Female/Male grouping dropped since Google does not publish gender metadata for these voices. Help text updated ("24 languages" → "70+ languages") to match Google's current multilingual capability. Default voice `Aoede` preserved; no backend changes — the `google_live` provider already accepts any string, so all 22 new voices work with existing operator YAML configs unchanged.
+
+### Fixed
+
+- **Google Live voice picker data-loss footgun (#349)**: Voice picker now renders a "Custom" optgroup for YAML-configured voices outside the 30-voice Gemini catalog (e.g. a new Google voice before we ship a UI update), mirroring the existing pattern on the model picker. Previously, a controlled `<select>` with a value not matching any `<option>` fell through to browser-default rendering (first option selected visually while React state held the configured value), so operators "fixing" the mismatched display silently overwrote their YAML-set custom voice on save.
+
 ### Planned
 
 - Additional provider integrations

--- a/admin_ui/frontend/src/components/config/providers/GenericProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GenericProviderForm.tsx
@@ -65,7 +65,13 @@ const PROVIDER_OPTIONS: Record<string, Record<string, string[]>> = {
     google_live: {
         model: GOOGLE_LIVE_SUGGESTED_MODELS,
         llm_model: GOOGLE_LIVE_SUGGESTED_MODELS,
-        tts_voice_name: ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'],
+        tts_voice_name: [
+            'Achernar', 'Achird', 'Algenib', 'Algieba', 'Alnilam', 'Aoede', 'Autonoe',
+            'Callirrhoe', 'Charon', 'Despina', 'Enceladus', 'Erinome', 'Fenrir', 'Gacrux',
+            'Iapetus', 'Kore', 'Laomedeia', 'Leda', 'Orus', 'Puck', 'Pulcherrima',
+            'Rasalgethi', 'Sadachbia', 'Sadaltager', 'Schedar', 'Sulafat', 'Umbriel',
+            'Vindemiatrix', 'Zephyr', 'Zubenelgenubi',
+        ],
     },
     minimax: {
         chat_model: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],

--- a/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
@@ -10,6 +10,14 @@ import {
     normalizeGoogleLiveModelForUi,
 } from '../../../utils/googleLiveModels';
 
+const GOOGLE_LIVE_SUPPORTED_VOICE_NAMES = [
+    'Achernar', 'Achird', 'Algenib', 'Algieba', 'Alnilam', 'Aoede', 'Autonoe',
+    'Callirrhoe', 'Charon', 'Despina', 'Enceladus', 'Erinome', 'Fenrir', 'Gacrux',
+    'Iapetus', 'Kore', 'Laomedeia', 'Leda', 'Orus', 'Puck', 'Pulcherrima',
+    'Rasalgethi', 'Sadachbia', 'Sadaltager', 'Schedar', 'Sulafat', 'Umbriel',
+    'Vindemiatrix', 'Zephyr', 'Zubenelgenubi',
+];
+
 interface VertexRegion {
     value: string;
     label: string;
@@ -439,6 +447,11 @@ const GoogleLiveProviderForm: React.FC<GoogleLiveProviderFormProps> = ({ config,
                             <option value="Vindemiatrix">Vindemiatrix — Gentle</option>
                             <option value="Zephyr">Zephyr — Bright</option>
                             <option value="Zubenelgenubi">Zubenelgenubi — Casual</option>
+                            {config.tts_voice_name && !GOOGLE_LIVE_SUPPORTED_VOICE_NAMES.includes(config.tts_voice_name) && (
+                                <optgroup label="Custom">
+                                    <option value={config.tts_voice_name}>{config.tts_voice_name}</option>
+                                </optgroup>
+                            )}
                         </select>
                         <p className="text-xs text-muted-foreground">
                             Multilingual voices — auto-switch across 70+ languages without configuration.

--- a/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
@@ -409,22 +409,40 @@ const GoogleLiveProviderForm: React.FC<GoogleLiveProviderFormProps> = ({ config,
                             value={config.tts_voice_name || 'Aoede'}
                             onChange={(e) => handleChange('tts_voice_name', e.target.value)}
                         >
-                            <optgroup label="Female">
-                                <option value="Aoede">Aoede</option>
-                                <option value="Kore">Kore</option>
-                                <option value="Leda">Leda</option>
-                            </optgroup>
-                            <optgroup label="Male">
-                                <option value="Puck">Puck</option>
-                                <option value="Charon">Charon</option>
-                                <option value="Fenrir">Fenrir</option>
-                                <option value="Orus">Orus</option>
-                                <option value="Zephyr">Zephyr</option>
-                            </optgroup>
+                            <option value="Achernar">Achernar — Soft</option>
+                            <option value="Achird">Achird — Friendly</option>
+                            <option value="Algenib">Algenib — Gravelly</option>
+                            <option value="Algieba">Algieba — Smooth</option>
+                            <option value="Alnilam">Alnilam — Firm</option>
+                            <option value="Aoede">Aoede — Breezy</option>
+                            <option value="Autonoe">Autonoe — Bright</option>
+                            <option value="Callirrhoe">Callirrhoe — Easy-going</option>
+                            <option value="Charon">Charon — Informative</option>
+                            <option value="Despina">Despina — Smooth</option>
+                            <option value="Enceladus">Enceladus — Breathy</option>
+                            <option value="Erinome">Erinome — Clear</option>
+                            <option value="Fenrir">Fenrir — Excitable</option>
+                            <option value="Gacrux">Gacrux — Mature</option>
+                            <option value="Iapetus">Iapetus — Clear</option>
+                            <option value="Kore">Kore — Firm</option>
+                            <option value="Laomedeia">Laomedeia — Upbeat</option>
+                            <option value="Leda">Leda — Youthful</option>
+                            <option value="Orus">Orus — Firm</option>
+                            <option value="Puck">Puck — Upbeat</option>
+                            <option value="Pulcherrima">Pulcherrima — Forward</option>
+                            <option value="Rasalgethi">Rasalgethi — Informative</option>
+                            <option value="Sadachbia">Sadachbia — Lively</option>
+                            <option value="Sadaltager">Sadaltager — Knowledgeable</option>
+                            <option value="Schedar">Schedar — Even</option>
+                            <option value="Sulafat">Sulafat — Warm</option>
+                            <option value="Umbriel">Umbriel — Easy-going</option>
+                            <option value="Vindemiatrix">Vindemiatrix — Gentle</option>
+                            <option value="Zephyr">Zephyr — Bright</option>
+                            <option value="Zubenelgenubi">Zubenelgenubi — Casual</option>
                         </select>
                         <p className="text-xs text-muted-foreground">
-                            Multilingual voices - auto-switches between 24 languages without configuration.
-                            <a href="https://firebase.google.com/docs/ai-logic/live-api/configuration" target="_blank" rel="noopener noreferrer" className="ml-1 text-blue-500 hover:underline">Voice Docs ↗</a>
+                            Multilingual voices — auto-switch across 70+ languages without configuration.
+                            <a href="https://ai.google.dev/gemini-api/docs/speech-generation" target="_blank" rel="noopener noreferrer" className="ml-1 text-blue-500 hover:underline">Voice Docs ↗</a>
                         </p>
                     </div>
                     <div className="space-y-2">

--- a/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
@@ -10,13 +10,40 @@ import {
     normalizeGoogleLiveModelForUi,
 } from '../../../utils/googleLiveModels';
 
-const GOOGLE_LIVE_SUPPORTED_VOICE_NAMES = [
-    'Achernar', 'Achird', 'Algenib', 'Algieba', 'Alnilam', 'Aoede', 'Autonoe',
-    'Callirrhoe', 'Charon', 'Despina', 'Enceladus', 'Erinome', 'Fenrir', 'Gacrux',
-    'Iapetus', 'Kore', 'Laomedeia', 'Leda', 'Orus', 'Puck', 'Pulcherrima',
-    'Rasalgethi', 'Sadachbia', 'Sadaltager', 'Schedar', 'Sulafat', 'Umbriel',
-    'Vindemiatrix', 'Zephyr', 'Zubenelgenubi',
-];
+const GOOGLE_LIVE_VOICE_OPTIONS = [
+    { value: 'Achernar', tone: 'Soft' },
+    { value: 'Achird', tone: 'Friendly' },
+    { value: 'Algenib', tone: 'Gravelly' },
+    { value: 'Algieba', tone: 'Smooth' },
+    { value: 'Alnilam', tone: 'Firm' },
+    { value: 'Aoede', tone: 'Breezy' },
+    { value: 'Autonoe', tone: 'Bright' },
+    { value: 'Callirrhoe', tone: 'Easy-going' },
+    { value: 'Charon', tone: 'Informative' },
+    { value: 'Despina', tone: 'Smooth' },
+    { value: 'Enceladus', tone: 'Breathy' },
+    { value: 'Erinome', tone: 'Clear' },
+    { value: 'Fenrir', tone: 'Excitable' },
+    { value: 'Gacrux', tone: 'Mature' },
+    { value: 'Iapetus', tone: 'Clear' },
+    { value: 'Kore', tone: 'Firm' },
+    { value: 'Laomedeia', tone: 'Upbeat' },
+    { value: 'Leda', tone: 'Youthful' },
+    { value: 'Orus', tone: 'Firm' },
+    { value: 'Puck', tone: 'Upbeat' },
+    { value: 'Pulcherrima', tone: 'Forward' },
+    { value: 'Rasalgethi', tone: 'Informative' },
+    { value: 'Sadachbia', tone: 'Lively' },
+    { value: 'Sadaltager', tone: 'Knowledgeable' },
+    { value: 'Schedar', tone: 'Even' },
+    { value: 'Sulafat', tone: 'Warm' },
+    { value: 'Umbriel', tone: 'Easy-going' },
+    { value: 'Vindemiatrix', tone: 'Gentle' },
+    { value: 'Zephyr', tone: 'Bright' },
+    { value: 'Zubenelgenubi', tone: 'Casual' },
+] as const;
+
+const GOOGLE_LIVE_SUPPORTED_VOICE_NAMES = GOOGLE_LIVE_VOICE_OPTIONS.map((v) => v.value);
 
 interface VertexRegion {
     value: string;
@@ -417,36 +444,11 @@ const GoogleLiveProviderForm: React.FC<GoogleLiveProviderFormProps> = ({ config,
                             value={config.tts_voice_name || 'Aoede'}
                             onChange={(e) => handleChange('tts_voice_name', e.target.value)}
                         >
-                            <option value="Achernar">Achernar — Soft</option>
-                            <option value="Achird">Achird — Friendly</option>
-                            <option value="Algenib">Algenib — Gravelly</option>
-                            <option value="Algieba">Algieba — Smooth</option>
-                            <option value="Alnilam">Alnilam — Firm</option>
-                            <option value="Aoede">Aoede — Breezy</option>
-                            <option value="Autonoe">Autonoe — Bright</option>
-                            <option value="Callirrhoe">Callirrhoe — Easy-going</option>
-                            <option value="Charon">Charon — Informative</option>
-                            <option value="Despina">Despina — Smooth</option>
-                            <option value="Enceladus">Enceladus — Breathy</option>
-                            <option value="Erinome">Erinome — Clear</option>
-                            <option value="Fenrir">Fenrir — Excitable</option>
-                            <option value="Gacrux">Gacrux — Mature</option>
-                            <option value="Iapetus">Iapetus — Clear</option>
-                            <option value="Kore">Kore — Firm</option>
-                            <option value="Laomedeia">Laomedeia — Upbeat</option>
-                            <option value="Leda">Leda — Youthful</option>
-                            <option value="Orus">Orus — Firm</option>
-                            <option value="Puck">Puck — Upbeat</option>
-                            <option value="Pulcherrima">Pulcherrima — Forward</option>
-                            <option value="Rasalgethi">Rasalgethi — Informative</option>
-                            <option value="Sadachbia">Sadachbia — Lively</option>
-                            <option value="Sadaltager">Sadaltager — Knowledgeable</option>
-                            <option value="Schedar">Schedar — Even</option>
-                            <option value="Sulafat">Sulafat — Warm</option>
-                            <option value="Umbriel">Umbriel — Easy-going</option>
-                            <option value="Vindemiatrix">Vindemiatrix — Gentle</option>
-                            <option value="Zephyr">Zephyr — Bright</option>
-                            <option value="Zubenelgenubi">Zubenelgenubi — Casual</option>
+                            {GOOGLE_LIVE_VOICE_OPTIONS.map((voice) => (
+                                <option key={voice.value} value={voice.value}>
+                                    {voice.value} — {voice.tone}
+                                </option>
+                            ))}
                             {config.tts_voice_name && !GOOGLE_LIVE_SUPPORTED_VOICE_NAMES.includes(config.tts_voice_name) && (
                                 <optgroup label="Custom">
                                     <option value={config.tts_voice_name}>{config.tts_voice_name}</option>


### PR DESCRIPTION
## Summary

Expands the `google_live` TTS voice picker in the admin UI from 8 hardcoded voices (arbitrarily split Female/Male) to the full 30-voice catalog that Gemini native-audio Live models support, labeled with Google's official tone descriptors (Bright, Firm, Smooth, etc.). Adds a "Custom" optgroup fallback so operators who configure a voice via YAML — or a voice Google adds after our UI update — can see and preserve their current selection. Also updates adjacent help text stale since 2024 (Firebase doc link → official Google AI speech-generation docs, "24 languages" → "70+ languages" per current docs).

Frontend-only. No backend changes, no schema changes, no migrations. Existing operator YAML configs continue to work unchanged — the `google_live` provider already accepts any string as the voice name.

## Related Issue(s)

- GitHub issue(s): Closes #349
- Split out during this work:
  - #350 — Support `gemini-3.1-flash-live-preview` (requires message envelope + session config work; was tried on this branch and reverted after a failed smoke-test — see branch history)
  - #351 — Barge-in broken on google_live Developer API mode (pre-existing regression, unrelated, surfaced during voice-picker smoke testing on dev server)

## Implementation Notes

- Key files touched:
  - `admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx` — voice dropdown 8 → 30 voices, drop Female/Male optgroups, add "Custom" fallback optgroup, fix stale help text + doc link
  - `admin_ui/frontend/src/components/config/providers/GenericProviderForm.tsx` — autocomplete suggestion list 8 → 30 voices (stays consistent with dedicated form)
  - `CHANGELOG.md` — Unreleased entries under Added + Fixed

- High-level design decisions:
  - **Flat alphabetical list with "Name — tone" labels** over grouped-by-tone or grouped-by-gender. Google publishes tone descriptors officially; gender is not officially published and would require guessing for 22 of the 30 voices.
  - **Keep `Aoede` as default** — no migration for existing configs; all 8 original voices preserved in the new list.
  - **"Custom" optgroup pattern** mirrors the existing model picker at `GoogleLiveProviderForm.tsx:392-396`. Same prevention of silent data loss when a controlled `<select>` receives a value not in its `<option>` list.
  - **Held back from this PR** (tracked separately):
    - #350's 3.1 model support (real breaking envelope changes, not a label swap)
    - Shared `GoogleProviderConfig` default `en-US-Neural2-C` is wrong for google_live but correct for classic Google TTS — needs backend config-class split, architectural change

## Testing

- [ ] Unit tests: none added — no existing voice-list assertions to extend, and the change is static data + a conditional render
- [x] Integration / manual tests on dev server `voiprnd.nemtclouddispatch.com`:
  - Admin UI loads, google_live provider config renders
  - Voice dropdown shows 30 voices alphabetically with tone descriptors
  - Default `Aoede` still selected for unset configs
  - Help text reads "auto-switch across 70+ languages" with link to `ai.google.dev/gemini-api/docs/speech-generation`
  - Live call with new voice (non-original-8) → audio plays correctly, voice sounds distinct from Aoede
  - Custom optgroup test: set `tts_voice_name: TestVoice123` via YAML, opened UI → picker shows "Custom" optgroup with `TestVoice123` selected; changed unrelated field (Temperature 0.4 → 0.3) and saved → `TestVoice123` preserved (not clobbered) — confirmed via server-side `grep` on config file after save
  - Toggle Vertex AI / Developer API → voice picker unchanged, correct models gated in each group

For telephony changes:

- Test call IDs:
  - Voice playback verified on user dev test call (2026-04-23)
  - #351 barge-in issue discovered on calls `1776975978.1562` (Dev API, broken) and `1776982184.1592` (Vertex, works) — predates this PR, tracked separately
- Providers/pipelines involved:
  - `google_live` (Vertex AI mode, `gemini-live-2.5-flash-native-audio`)
- Brief call behavior summary:
  - New voice selection plays audio correctly; no regression introduced.
  - Pre-existing barge-in issue on Developer API mode surfaced (#351). Not caused by this PR.

## Documentation

- `CHANGELOG.md` updated with Unreleased entries (Added + Fixed)
- No other docs updated — UI enhancement surfacing existing backend capabilities. Tooltip help text under the picker is updated in-line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded voice catalog to 30 Gemini Live voices with tone-based descriptors
  * Added a “Custom” option for YAML-defined voices not in the standard catalog
  * Updated help text to reflect broader multilingual coverage (70+ languages) and docs link

* **Bug Fixes**
  * Fixed voice picker mismatch that could silently overwrite custom voice selections on save
<!-- end of auto-generated comment: release notes by coderabbit.ai -->