### PR TITLE
fix(ari): handle clean websocket listener termination

### DIFF
--- a/src/ari_client.py
+++ b/src/ari_client.py
@@ -172,8 +172,14 @@ class ARIClient:
         if exc_info:
             kwargs["exc_info"] = True
         log(message, **kwargs)
-        await asyncio.sleep(backoff)
-        return True
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + backoff
+        while self._should_reconnect:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return True
+            await asyncio.sleep(min(remaining, 0.5))
+        return False
 
     async def _listen_with_reconnect(self):
         """

--- a/src/ari_client.py
+++ b/src/ari_client.py
@@ -199,15 +199,12 @@ class ARIClient:
                 try:
                     await self.connect()
                 except Exception as e:
-                    self._reconnect_attempt += 1
-                    backoff = min(2 ** self._reconnect_attempt, self._max_reconnect_backoff)
-                    logger.warning(
+                    should_continue = await self._mark_disconnected_and_backoff(
                         "ARI connection failed, will retry",
-                        attempt=self._reconnect_attempt,
-                        backoff_seconds=backoff,
-                        error=str(e)
+                        error=str(e),
                     )
-                    await asyncio.sleep(backoff)
+                    if not should_continue:
+                        break
                     continue
 
             logger.info("Starting ARI event listener.")

--- a/src/ari_client.py
+++ b/src/ari_client.py
@@ -4,6 +4,7 @@ Focuses on robust connection and logging to debug startup issues.
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import time
@@ -52,6 +53,7 @@ class ARIClient:
         self._reconnect_attempt = 0
         self._max_reconnect_backoff = 60  # Max seconds between reconnect attempts
         self._connected = False  # True readiness state for /ready endpoint
+        self._listener_active = False  # Guard against duplicate listener supervisors
         self.event_handlers: Dict[str, List[Callable]] = {}
         self.active_playbacks: Dict[str, str] = {}
         self.audio_frame_handler: Optional[Callable] = None
@@ -103,7 +105,13 @@ class ARIClient:
                     raise ConnectionError(f"Failed to connect to ARI HTTP endpoint. Status: {response.status}")
                 logger.info("Successfully connected to ARI HTTP endpoint.", scheme=http_scheme, ssl_verify=self.ssl_verify)
 
-            # Then, connect to the WebSocket
+            # Then, connect to the WebSocket. Close any stale socket first so a reconnect
+            # never reuses a dead iterator.
+            if self.websocket is not None:
+                with contextlib.suppress(Exception):
+                    await self.websocket.close()
+                self.websocket = None
+
             self.websocket = await websockets.connect(self.ws_url, ssl=ssl_context)
             self.running = True
             self._connected = True
@@ -119,7 +127,53 @@ class ARIClient:
 
     async def start_listening(self):
         """Start listening for events from the ARI WebSocket with automatic reconnection."""
-        await self._listen_with_reconnect()
+        if self._listener_active:
+            logger.warning("ARI listener already active; ignoring duplicate start")
+            return
+
+        self._listener_active = True
+        self._should_reconnect = True
+        try:
+            await self._listen_with_reconnect()
+        finally:
+            self._listener_active = False
+
+    async def _mark_disconnected_and_backoff(
+        self,
+        message: str,
+        *,
+        level: str = "warning",
+        error: Optional[str] = None,
+        exc_info: bool = False,
+    ) -> bool:
+        """Clear ARI connection state and sleep before reconnecting."""
+        self._connected = False
+        self.running = False
+
+        websocket = self.websocket
+        self.websocket = None
+        if websocket is not None:
+            with contextlib.suppress(Exception):
+                await websocket.close()
+
+        if not self._should_reconnect:
+            logger.info(f"{message} (shutdown requested).")
+            return False
+
+        self._reconnect_attempt += 1
+        backoff = min(2 ** self._reconnect_attempt, self._max_reconnect_backoff)
+        log = logger.error if level == "error" else logger.warning
+        kwargs = {
+            "attempt": self._reconnect_attempt,
+            "backoff_seconds": backoff,
+        }
+        if error is not None:
+            kwargs["error"] = error
+        if exc_info:
+            kwargs["exc_info"] = True
+        log(message, **kwargs)
+        await asyncio.sleep(backoff)
+        return True
 
     async def _listen_with_reconnect(self):
         """
@@ -172,41 +226,30 @@ class ARIClient:
                                 asyncio.create_task(handler(event_data))
                     except json.JSONDecodeError:
                         logger.warning("Failed to decode ARI event JSON", message=message)
+
+                # A clean iterator end is still a disconnect. Without this branch the outer
+                # loop immediately re-enters with the stale websocket and spams listener logs.
+                should_continue = await self._mark_disconnected_and_backoff(
+                    "ARI WebSocket listener ended, will reconnect"
+                )
+                if not should_continue:
+                    break
                         
             except ConnectionClosed:
-                self._connected = False
-                self.running = False
-                self.websocket = None
-                if self._should_reconnect:
-                    self._reconnect_attempt += 1
-                    backoff = min(2 ** self._reconnect_attempt, self._max_reconnect_backoff)
-                    logger.warning(
-                        "ARI WebSocket connection closed, will reconnect",
-                        attempt=self._reconnect_attempt,
-                        backoff_seconds=backoff
-                    )
-                    await asyncio.sleep(backoff)
-                else:
-                    logger.info("ARI WebSocket closed (shutdown requested).")
+                should_continue = await self._mark_disconnected_and_backoff(
+                    "ARI WebSocket connection closed, will reconnect"
+                )
+                if not should_continue:
                     break
                     
             except Exception as e:
-                self._connected = False
-                self.running = False
-                self.websocket = None
-                if self._should_reconnect:
-                    self._reconnect_attempt += 1
-                    backoff = min(2 ** self._reconnect_attempt, self._max_reconnect_backoff)
-                    logger.error(
-                        "ARI listener error, will reconnect",
-                        attempt=self._reconnect_attempt,
-                        backoff_seconds=backoff,
-                        error=str(e),
-                        exc_info=True
-                    )
-                    await asyncio.sleep(backoff)
-                else:
-                    logger.error("ARI listener error (shutdown requested).", exc_info=True)
+                should_continue = await self._mark_disconnected_and_backoff(
+                    "ARI listener error, will reconnect",
+                    level="error",
+                    error=str(e),
+                    exc_info=True,
+                )
+                if not should_continue:
                     break
         
         logger.info("ARI reconnect supervisor stopped.")
@@ -220,7 +263,8 @@ class ARIClient:
         self._connected = False
         self.running = False
         if self.websocket:
-            await self.websocket.close()
+            with contextlib.suppress(Exception):
+                await self.websocket.close()
             self.websocket = None
         if self.http_session and not self.http_session.closed:
             await self.http_session.close()

--- a/tests/test_ari_client_reconnect.py
+++ b/tests/test_ari_client_reconnect.py
@@ -44,3 +44,29 @@ async def test_ari_listener_handles_clean_iterator_end_without_tight_loop(monkey
     assert websocket.closed is True
     assert sleeps == [0.5]
     assert client._reconnect_attempt == 1
+
+
+@pytest.mark.unit
+async def test_ari_listener_connect_failure_backoff_stops_on_shutdown(monkeypatch):
+    client = ARIClient("user", "pass", "http://asterisk:8088/ari", "ava")
+    client._should_reconnect = True
+
+    async def fail_connect():
+        raise ConnectionError("ARI not ready")
+
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+        client._should_reconnect = False
+
+    monkeypatch.setattr(client, "connect", fail_connect)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    await client._listen_with_reconnect()
+
+    assert client.running is False
+    assert client._connected is False
+    assert client.websocket is None
+    assert sleeps == [0.5]
+    assert client._reconnect_attempt == 1

--- a/tests/test_ari_client_reconnect.py
+++ b/tests/test_ari_client_reconnect.py
@@ -42,5 +42,5 @@ async def test_ari_listener_handles_clean_iterator_end_without_tight_loop(monkey
     assert client._connected is False
     assert client.websocket is None
     assert websocket.closed is True
-    assert sleeps == [2]
+    assert sleeps == [0.5]
     assert client._reconnect_attempt == 1

--- a/tests/test_ari_client_reconnect.py
+++ b/tests/test_ari_client_reconnect.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import pytest
+
+from src.ari_client import ARIClient
+
+
+class _CleanlyEndingWebSocket:
+    def __init__(self):
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.unit
+async def test_ari_listener_handles_clean_iterator_end_without_tight_loop(monkeypatch):
+    client = ARIClient("user", "pass", "http://asterisk:8088/ari", "ava")
+    websocket = _CleanlyEndingWebSocket()
+    client._should_reconnect = True
+    client.running = True
+    client._connected = True
+    client.websocket = websocket
+
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+        client._should_reconnect = False
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    await client._listen_with_reconnect()
+
+    assert client.running is False
+    assert client._connected is False
+    assert client.websocket is None
+    assert websocket.closed is True
+    assert sleeps == [2]
+    assert client._reconnect_attempt == 1


### PR DESCRIPTION
## Summary

Fixes #360.

This hardens the ARI reconnect supervisor so a clean WebSocket iterator termination is treated as a real disconnect instead of falling through into a tight listener loop.

## Root Cause

`ARIClient._listen_with_reconnect()` handled `ConnectionClosed` and generic exceptions, but it did not handle the case where:

```python
async for message in self.websocket:
    ...
```

ends normally without raising. In that path, `self.running`, `self._connected`, and `self.websocket` stayed truthy, so the outer reconnect loop skipped `connect()` and immediately logged `Starting ARI event listener.` again.

## Changes

- Clear ARI connection state and close stale WebSockets through one reconnect/backoff helper.
- Treat clean ARI WebSocket listener termination as a disconnect with exponential backoff.
- Close stale WebSockets before establishing a replacement connection.
- Add a duplicate listener guard around `start_listening()`.
- Add a regression test for a WebSocket async iterator that ends immediately.

## Impact

After an Asterisk/FreePBX restart or clean ARI WebSocket close, AVA should now mark ARI disconnected, back off, and reconnect instead of entering a tight log/CPU loop.

## Validation

```bash
.venv/bin/python -m pytest tests/test_ari_client_reconnect.py tests/test_engine_ari_startup_reconnect.py
```

Result: `2 passed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust WebSocket lifecycle: safer reconnects, suppressed shutdown errors, reliable cleanup, and reduced duplicate listener supervisors
  * Unified reconnect/backoff handling to avoid stale sockets and noisy listener logs

* **Tests**
  * Added unit tests covering reconnect behavior for both clean iterator termination and immediate connection failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->