### PR TITLE
Handle OpenAI streaming timeouts gracefully

### DIFF
--- a/src/pipelines/openai.py
+++ b/src/pipelines/openai.py
@@ -760,6 +760,13 @@ class OpenAILLMAdapter(LLMComponent):
                     tools=[tc["name"] for tc in self._pending_tool_calls_by_call[call_id]],
                 )
 
+        except asyncio.TimeoutError as e:
+            logger.warning(
+                "OpenAI streaming timed out; falling back to serial path",
+                call_id=call_id,
+                timeout_sec=merged["timeout_sec"],
+                error=str(e),
+            )
         except aiohttp.ClientError as e:
             logger.error("OpenAI streaming connection error", call_id=call_id, error=str(e))
 

--- a/tests/test_pipeline_openai_adapters.py
+++ b/tests/test_pipeline_openai_adapters.py
@@ -110,6 +110,30 @@ class _FakeSession:
         self.closed = True
 
 
+class _TimeoutStream:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise asyncio.TimeoutError("simulated first-token timeout")
+
+
+class _FakeStreamingResponse(_FakeResponse):
+    def __init__(self, content, status: int = 200):
+        super().__init__(b"", status=status)
+        self.content = content
+
+
+class _FakeStreamingSession(_FakeSession):
+    def __init__(self, content, status: int = 200):
+        super().__init__(b"", status=status)
+        self._content = content
+
+    def post(self, url, json=None, data=None, headers=None, timeout=None):
+        self.requests.append({"url": url, "json": json, "data": data, "headers": headers, "timeout": timeout})
+        return _FakeStreamingResponse(self._content, status=self._status)
+
+
 @pytest.mark.asyncio
 async def test_openai_stt_adapter_transcribes(monkeypatch):
     app_config = _build_app_config()
@@ -158,6 +182,28 @@ async def test_openai_llm_adapter_chat_completion(monkeypatch):
     request = fake_session.requests[0]
     assert request["json"]["model"] == "gpt-4o-mini"
     assert request["json"]["messages"][-1] == {"role": "user", "content": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_openai_llm_stream_timeout_returns_empty_for_serial_fallback():
+    app_config = _build_app_config()
+    provider_config = OpenAIProviderConfig(**app_config.providers["openai"])
+    fake_session = _FakeStreamingSession(_TimeoutStream())
+    adapter = OpenAILLMAdapter(
+        "openai_llm",
+        app_config,
+        provider_config,
+        {"use_realtime": False, "timeout_sec": 1.5},
+        session_factory=lambda: fake_session,
+    )
+
+    await adapter.start()
+    chunks = [chunk async for chunk in adapter.generate_stream("call-1", "hello", {"system_prompt": "You are helpful."}, {})]
+
+    assert chunks == []
+    assert fake_session.requests[0]["json"]["stream"] is True
+    assert fake_session.requests[0]["timeout"] == 1.5
+    assert adapter._pending_tool_calls_by_call["call-1"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- catch `asyncio.TimeoutError` from the OpenAI streaming response iterator
- log it as a streaming timeout/fallback condition instead of letting it bubble as an engine error
- add a mocked first-token timeout regression test for the streaming adapter

Fixes #371.

## Verification
- `python3 -m py_compile src/pipelines/openai.py tests/test_pipeline_openai_adapters.py`
- `python3 -m pytest tests/test_pipeline_openai_adapters.py -q` (6 passed)

No OpenAI keys, VoIP servers, call recordings, or paid infrastructure were used. The timeout path is covered with a mocked async stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for timeout errors during OpenAI streaming operations. The system now logs timeout incidents with relevant context and details, improving the ability to diagnose and troubleshoot issues when streaming requests exceed the configured timeout threshold.

* **Tests**
  * Added test coverage for timeout scenarios in streaming mode to ensure reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->